### PR TITLE
docs: add grammar syntax definition

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -2,12 +2,32 @@ Grammar
 ========
 
 # Grammar Syntax Definition
-## Netlists
+```
+module                                                  (can ignore that)
+import                                                  (can ignore that)
+program -> {decl}                 
+decl    -> ident :: type                                (function declaration, type signature, get rid of "context" from Haskell)
+         | decllhs "=" declrhs                          (function definition)
+types   -> type
+         | types "->" types                             (function type)
+         | "("types {"," types} ")"                     (tuple type, at least 2 elements)
+         | "[" types "]"                                (list type)
+type    -> "Int" | "Signal" type                        (basic type or Signal wrapper)
+declrhs -> expr ["where" {decl}]
+decllhs -> ident                                        (value binding)
+         | ident {pattern}                              (function definition)
+         | "(" pattern "," pattern {"," pattern} ")"    (tuple pattern binding)
+         | "["(pattern) {"," pattern}"]"                (list pattern binding)
+pattern -> ident | intlit
+         | "(" pattern "," pattern {"," pattern} ")"    (tuple, should be at least 2 elements)
+         | "["(pattern) {"," pattern}"]"                (list, can be empty, should have same type)
+expr    -> ident | intlit
+         | expr binop expr
+         | unop expr
+         | expr expr                                    (function application)
+         | "(" expr, expr {"," expr} ")"
+         | "["(expr) {"," expr}"]"
+         | "\" pattern "->" expr                        (lambda functions)
 
-## Process Network
-
-## Process Constructors
-
-## Process Functions
-
-# Grammar Semantics
+```
+# Grammar Semantics (Abstract Syntax)


### PR DESCRIPTION
Hi,

I have created a fundamental version of the syntax definition. I refered to Klara's SDF example code in Discord, so the syntax can support a more Haskell-like feature, like the lambda functions. Also the syntax will not differenciate the netlists, processes and functions and all treated as declarations. But this kind of high freedom of syntax might result in a difficulty in pattern matching. For the netlist we can specify that a function named system is necessary, just like the main function in C. 

The syntax might not be perfect and we can make it more specific later for easier implementation