### PR TITLE
Setting up ForSyDe IR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ result-*
 
 # Ignore automatically generated direnv output
 .direnv
+
+tests/

--- a/docs/forsyde-ir.md
+++ b/docs/forsyde-ir.md
@@ -1,0 +1,23 @@
+# ForSyDe IR Documentation
+The ForSyDe IR can be found in the file `src/ForSyDeIR.hs`. The defined data types for the IR in Haskell are provided below.
+```haskell
+data ActorType
+  = Actor11
+  | Actor22
+data IRConstructor 
+  = IRDelay String
+  | IRActor String ActorType String
+data IRSignal = IRSignal String (String, Int) (String, Int)
+data IRFunction = IRFunction String (Maybe CoreExpr)
+data IRSystem = IRSystem [IRConstructor] [IRSignal] [IRFunction]
+```
+
+## Pretty Printing
+The pretty printing for the ForSyDe IR is also defined under `src/ForSyDeIR.hs`. A summary is provided below. Note that whitespace should be ignored. The pretty printing for `ActorType` is the same as the type it represents.
+- `constructor`: `IRDelay(delayId)`, `IRActor(actorID, actorType, functionId)`
+- `signal`: `IRSignal(signalId, (sourceId, sourceRate), (targetId, targetRate))`
+- `function`: `IRFunction(functionId, [ function ])`
+- `system`: `IRSystem({ constructors }, { signals }, { functions } )`
+
+## Naming Convention
+The naming convention of the ForSyDe IR data types is to just use the umbrella term provided by the ForSyDe Shallow documentation and prefix `IR`. Make sure to use upper camel case.

--- a/forsyde-devtools.cabal
+++ b/forsyde-devtools.cabal
@@ -22,6 +22,7 @@ executable forsyde-devtools-exe
     ghc-options:    -threaded -rtsopts -with-rtsopts=-N
     other-modules:
         Arguments
+        ForSyDeIR
     build-depends:
         base >=4.6 && <6,
         ghc == 9.8.4,

--- a/src/ForSyDeIR.hs
+++ b/src/ForSyDeIR.hs
@@ -23,6 +23,7 @@ data ActorType
   | Actor42
   | Actor43
   | Actor44
+  deriving (Show)
 
 data IRConstructor
   = IRDelay String
@@ -35,24 +36,6 @@ data IRFunction = IRFunction String (Maybe CoreExpr)
 data IRSystem = IRSystem [IRConstructor] [IRSignal] [IRFunction]
 
 -- Pretty printing functions for ForSyDe IR
-
-prettyActorType :: ActorType -> SDoc
-prettyActorType Actor11 = text "Actor11"
-prettyActorType Actor12 = text "Actor12"
-prettyActorType Actor13 = text "Actor13"
-prettyActorType Actor14 = text "Actor14"
-prettyActorType Actor21 = text "Actor21"
-prettyActorType Actor22 = text "Actor22"
-prettyActorType Actor23 = text "Actor23"
-prettyActorType Actor24 = text "Actor24"
-prettyActorType Actor31 = text "Actor31"
-prettyActorType Actor32 = text "Actor32"
-prettyActorType Actor33 = text "Actor33"
-prettyActorType Actor34 = text "Actor34"
-prettyActorType Actor41 = text "Actor41"
-prettyActorType Actor42 = text "Actor42"
-prettyActorType Actor43 = text "Actor43"
-prettyActorType Actor44 = text "Actor44"
 
 prettyIRSignal :: IRSignal -> SDoc
 prettyIRSignal (IRSignal signalId (inputId, inputRate) (outputId, outputRate)) =
@@ -83,7 +66,7 @@ prettyIRConstructor (IRActor actorId actorType functionId) =
     <+> parens
       ( text actorId
           <+> comma
-          <+> prettyActorType actorType
+          <+> text (show actorType)
           <+> comma
           <+> text functionId
       )

--- a/src/ForSyDeIR.hs
+++ b/src/ForSyDeIR.hs
@@ -1,0 +1,144 @@
+module ForSyDeIR where
+
+import GHC.Core
+import GHC.Core.Ppr (pprCoreExpr)
+import GHC.Utils.Outputable
+
+-- ForSyDe IR data types
+
+data ActorType
+  = Actor11
+  | Actor12
+  | Actor13
+  | Actor14
+  | Actor21
+  | Actor22
+  | Actor23
+  | Actor24
+  | Actor31
+  | Actor32
+  | Actor33
+  | Actor34
+  | Actor41
+  | Actor42
+  | Actor43
+  | Actor44
+
+data IRConstructor
+  = IRDelay String
+  | IRActor String ActorType String
+
+data IRSignal = IRSignal String (String, Int) (String, Int)
+
+data IRFunction = IRFunction String (Maybe CoreExpr)
+
+data IRSystem = IRSystem [IRConstructor] [IRSignal] [IRFunction]
+
+-- Pretty printing functions for ForSyDe IR
+
+prettyActorType :: ActorType -> SDoc
+prettyActorType Actor11 = text "Actor11"
+prettyActorType Actor12 = text "Actor12"
+prettyActorType Actor13 = text "Actor13"
+prettyActorType Actor14 = text "Actor14"
+prettyActorType Actor21 = text "Actor21"
+prettyActorType Actor22 = text "Actor22"
+prettyActorType Actor23 = text "Actor23"
+prettyActorType Actor24 = text "Actor24"
+prettyActorType Actor31 = text "Actor31"
+prettyActorType Actor32 = text "Actor32"
+prettyActorType Actor33 = text "Actor33"
+prettyActorType Actor34 = text "Actor34"
+prettyActorType Actor41 = text "Actor41"
+prettyActorType Actor42 = text "Actor42"
+prettyActorType Actor43 = text "Actor43"
+prettyActorType Actor44 = text "Actor44"
+
+prettyIRSignal :: IRSignal -> SDoc
+prettyIRSignal (IRSignal signalId (inputId, inputRate) (outputId, outputRate)) =
+  text "IRSignal"
+    <+> parens
+      ( text signalId
+          <+> comma
+          <+> parens
+            ( text inputId
+                <+> comma
+                <+> int inputRate
+            )
+          <+> comma
+          <+> parens
+            ( text outputId
+                <+> comma
+                <+> int outputRate
+            )
+      )
+
+prettyIRConstructor :: IRConstructor -> SDoc
+prettyIRConstructor (IRDelay delayId) =
+  text "IRDelay"
+    <+> parens
+      (text delayId)
+prettyIRConstructor (IRActor actorId actorType functionId) =
+  text "IRActor"
+    <+> parens
+      ( text actorId
+          <+> comma
+          <+> prettyActorType actorType
+          <+> comma
+          <+> text functionId
+      )
+
+prettyIRFunction :: IRFunction -> SDoc
+prettyIRFunction (IRFunction functionId function) =
+  text "IRFunction"
+    <+> parens
+      ( text functionId
+          <+> comma
+          <+> maybe empty pprCoreExpr function
+      )
+
+prettyIRSystem :: IRSystem -> SDoc
+prettyIRSystem (IRSystem constructors signals functions) =
+  text "IRSystem"
+    <+> parens
+      ( vcat
+          [ text "{"
+              $$ nest
+                2
+                ( vcat (punctuate comma (map prettyIRConstructor constructors))
+                )
+              $$ text "}",
+            text "{"
+              $$ nest
+                2
+                ( vcat (punctuate comma (map prettyIRSignal signals))
+                )
+              $$ text "}",
+            text "{"
+              $$ nest
+                2
+                ( vcat (punctuate comma (map prettyIRFunction functions))
+                )
+              $$ text "}"
+          ]
+      )
+
+-- Simple example to test ForSyDe IR
+
+exampleSystem :: IRSystem
+exampleSystem =
+  IRSystem
+    [ IRActor "actor_1" Actor22 "add",
+      IRDelay "delay_1"
+    ]
+    [ IRSignal "s_in" ("input", 1) ("actor_1", 1),
+      IRSignal "s_1" ("actor_1", 1) ("delay_1", 1),
+      IRSignal "s_2" ("delay_1", 1) ("actor_1", 1),
+      IRSignal "s_out" ("actor_1", 1) ("output", 1)
+    ]
+    [ IRFunction "add" Nothing
+    ]
+
+testForSyDeIR :: IO ()
+testForSyDeIR = do
+  putStrLn $ showSDocUnsafe $ prettyIRSystem exampleSystem


### PR DESCRIPTION
Defined ForSyDe IR data types and pretty printing functions. Wrote ForSyDe IR documentation based on this work. The `src/ForSyDeIR.hs` file includes a simple example system, which was used to test the pretty printing. This can be removed once we have unit testing working.

Relates to #35, #36, #37, #38, #123