### PR TITLE
Document testing and add example

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*.cabal]
+indent_style = space
+indent_size = 4
+
+[*.hs]
+indent_style = space
+indent_size = 2
+
+[*.nix]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,7 @@ jobs:
           nix_path: nixpkgs=channel:25.05
 
         # Runs a set of commands using the runners shell
-      - name: Build the compiler
+      - name: Build and test the compiler
         run: |
-          nix develop --command bash -c "cabal update"
           nix develop --command bash -c "cabal build"
-          nix develop --command bash -c "cabal new-test"
+          nix develop --command bash -c "cabal test"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,4 +30,6 @@ jobs:
         # Runs a set of commands using the runners shell
       - name: Build the compiler
         run: |
+          nix develop --command bash -c "cabal update"
           nix develop --command bash -c "cabal build"
+          nix develop --command bash -c "cabal new-test"

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,3 @@
 packages: ./
+package: forsyde-devtools
+tests: True

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,3 @@
 packages: ./
-package: forsyde-devtools
 tests: True
+package forsyde-devtools

--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -43,11 +43,16 @@ git push origin work/feature
 1. Separate commits for different parts of the project.
    E.g. if you contributed actor11SDF, you should separate the commits for e.g. the parser and the code generation.
 
-2. Do the feature work in your own fork.
+2. Do the feature work in your own fork. You should also include at least one new test,
+    see [Testing Documenation](testing.md) for more information.
 
-3. Create a pull request from the branch on the dev repo or via the link which appears when you push the new branch.
+3. Check that tests for other modules still complete successfully.
+    If there are failing tests which are *expected* to fail as a result of your work,
+    update the tests with the new expected behavior.
 
-4. Wait for someone else to review, and address any resulting comments.
+4. Create a pull request from the branch on the dev repo or via the link which appears when you push the new branch.
+
+5. Wait for someone else to review, and address any resulting comments.
 
 If there is no consensus on how to go forward it should be brought up
 in the next team meeting.

--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -13,11 +13,11 @@ git remote add upstream git@github.com:sthaeron/forsyde-devtools.git
 
 ### Sync your fork
 
-The local main branch can be updated e.g. by:
+The local dev branch can be updated e.g. by:
 
 ```
-git pull upstream main
-git push origin main
+git pull upstream dev
+git push origin dev
 ```
 
 ### Adding a new feature
@@ -32,7 +32,7 @@ When that's done, create a separate branch, e.g if you have added
 the main repo as the `upstream` remote:
 
 ```
-git checkout -b work/feature upstream/main
+git checkout -b work/feature upstream/dev
 # Do your work
 git commit
 git push origin work/feature
@@ -41,7 +41,7 @@ git push origin work/feature
 ### Feature Contribution Rule
 
 1. Separate commits for different parts of the project.
-   E.g. if you contributed actor11SDF, you should separate the commits for e.g. the parser and the code generation.
+   E.g. if you contributed actor11SDF, you should separate the commits for e.g. the ForSyDeIR and the code generation.
 
 2. Do the feature work in your own fork. You should also include at least one new test,
     see [Testing Documenation](testing.md) for more information.
@@ -115,7 +115,7 @@ incoming responses other than from latest request.
 nix-shell
 ```
 
-3. You now have all required dependencies (including OCaml and dune) available in your environment.
+3. You now have all required dependencies available in your environment.
 
 ## Continuous Integration
 
@@ -133,7 +133,7 @@ If you use the nix environment, this is done automatically, but otherwise:
 cp -r ./.githooks/. ./.git/hooks
 ```
 
-At this point, they are used to ensure a consistent formatting of OCaml source code.
+At this point, they are used to ensure a consistent formatting of Haskell source code.
 
 ### Github Actions
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -40,3 +40,37 @@ files in unexpected locations and can't be directly used by hpc.
 
 The tool can also generate HTML output with `hpc markup`, which among other things
 can annotate the source and show which parts of it have been exercised or not.
+
+
+## Usage in this project
+
+There is a sample test for the ForSyDeIR which can be used as a starting point.
+Modules which are to be tested should be exposed in the library so they are
+visible to the test suite and can be imported. The test for the module should
+be in the same path in `test` as the module is in `src` and have `Spec`
+appended to the end. If this is the case, hspec-discover will automatically
+run them when invoked with `cabal new-test` or `cabal test`. The Hspec
+documentation recommends passing `--test-show-details=direct` when using cabal.
+When run, it should show something like this:
+```
+...
+Running 1 test suites...
+Test suite spec: RUNNING...
+
+ForSyDeIR
+  IR pretty-printing
+    Test hand-crafted IRSystem [✔]
+    Empty IR-system should not be an empty string [✔]
+
+Finished in 0.0004 seconds
+2 examples, 0 failures
+Test suite spec: PASS
+Test suite logged to: ...
+...
+```
+
+In many cases, equality testing with `shouldBe` will be enough for basics, but
+[hspec-expectations](https://hspec.github.io/expectations.html) lists a few other
+which can also be useful.
+
+Using the QuickCheck integration is described in [hspec-quickcheck](https://hspec.github.io/quickcheck.html).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,42 @@
+# Testing Documentation
+
+There are a few different testing frameworks used for hasell, including
+QuickCheck, HUnit, and Hspec among others.
+
+[QuickCheck](https://www.cse.chalmers.se/~rjmh/QuickCheck/manual.html)
+is more akin to requirements testing, i.e. one specifies properties
+the program (or part of it) should fulfil which are used to generate test cases.
+In case you took the software reliability course (DD2459) this is somewhat similar to JML.
+
+[HUnit](https://hackage.haskell.org/package/HUnit) as the name suggests,
+is a unit testing framework similar to JUnit.
+This is a black-box testing approach, where the program (or part of it) is
+run for some input or scenario and the output is tested against some correctness criteria.
+The implementation details are not important other than the public interfaces.
+
+[Hspec](https://hspec.github.io/) integrates several testing framework into a common interface,
+such as HUnit and QuickCheck. This is what we will mainly use in this project.
+
+Additionally, GHC has some built-in tools for coverage testing (a glass-box testing technique)
+in the form of [HPC](https://wiki.haskell.org/Haskell_program_coverage).
+
+Sample run:
+```
+$ ghc -fhpc -package ghc src/Main.hs
+$ ./src/Main
+...
+$ hpc report Main
+ 95% expressions used (38/40)
+100% boolean coverage (0/0)
+     100% guards (0/0)
+     100% 'if' conditions (0/0)
+     100% qualifiers (0/0)
+100% alternatives used (0/0)
+100% local declarations used (0/0)
+100% top-level declarations used (1/1)
+```
+Or with cabal: `cabal run --enable-coverage` (though this seems to generate the .mix and .tix
+files in unexpected locations and can't be directly used by hpc.
+
+The tool can also generate HTML output with `hpc markup`, which among other things
+can annotate the source and show which parts of it have been exercised or not.

--- a/forsyde-devtools.cabal
+++ b/forsyde-devtools.cabal
@@ -11,19 +11,11 @@ license-file:       LICENSE
 build-type:         Simple
 extra-doc-files:    CHANGELOG.md
 
-common warnings
-    ghc-options: -Wall
-
-executable forsyde-devtools-exe
-    import:           warnings
-    main-is:          Main.hs
-    hs-source-dirs:   src
+common shared
+    ghc-options:      -Wall -threaded
     default-language: Haskell2010
-    ghc-options:    -threaded -rtsopts -with-rtsopts=-N
     other-modules:
-        Arguments
-        ForSyDeIR
-        CoreIR
+        Paths_forsyde_devtools
     build-depends:
         base >=4.6 && <6,
         ghc == 9.8.4,
@@ -31,3 +23,30 @@ executable forsyde-devtools-exe
         forsyde-shallow == 3.5.0.0,
         optparse-applicative >= 0.18.1.0,
         filepath == 1.4.301.0,
+
+library
+    import:           shared
+    hs-source-dirs:   src
+    exposed-modules:
+        Arguments
+        CoreIR
+        ForSyDeIR
+
+executable forsyde-devtools-exe
+    import:           shared
+    hs-source-dirs:   src
+    main-is:          Main.hs
+    ghc-options:      -rtsopts -with-rtsopts=-N
+    build-depends:
+        forsyde-devtools,
+
+test-suite spec
+    import:           shared
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   test
+    main-is:          Spec.hs
+    build-depends:
+        hspec == 2.11.*,
+        forsyde-devtools,
+    build-tool-depends:
+        hspec-discover:hspec-discover == 2.11.*

--- a/forsyde-devtools.cabal
+++ b/forsyde-devtools.cabal
@@ -9,13 +9,11 @@ license-file:       LICENSE
 -- maintainer:
 -- copyright:
 build-type:         Simple
-extra-doc-files:    CHANGELOG.md
+extra-doc-files:    README.md
 
-common shared
+common common-options
     ghc-options:      -Wall -threaded
     default-language: Haskell2010
-    other-modules:
-        Paths_forsyde_devtools
     build-depends:
         base >=4.6 && <6,
         ghc == 9.8.4,
@@ -25,7 +23,7 @@ common shared
         filepath == 1.4.301.0,
 
 library
-    import:           shared
+    import:           common-options
     hs-source-dirs:   src
     exposed-modules:
         Arguments
@@ -33,20 +31,21 @@ library
         ForSyDeIR
 
 executable forsyde-devtools-exe
-    import:           shared
+    import:           common-options
     hs-source-dirs:   src
     main-is:          Main.hs
     ghc-options:      -rtsopts -with-rtsopts=-N
-    build-depends:
-        forsyde-devtools,
+    build-depends:    forsyde-devtools
 
-test-suite spec
-    import:           shared
+
+test-suite forsyde-devtools-test
+    import:           common-options
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test
     main-is:          Spec.hs
+    ghc-options:      -threaded -rtsopts -with-rtsopts=-N
+    other-modules:
+        ForSyDeIRSpec
     build-depends:
-        hspec == 2.11.*,
         forsyde-devtools,
-    build-tool-depends:
-        hspec-discover:hspec-discover == 2.11.*
+        hspec,

--- a/hie.yaml
+++ b/hie.yaml
@@ -2,3 +2,5 @@ cradle:
   multi:
     - path: "src"
       config: {cradle: {cabal: {component: "forsyde-devtools:forsyde-devtools-exe"}}}
+    - path: "test"
+      config: {cradle: {cabal: {component: "forsyde-devtools:forsyde-devtools-test"}}}

--- a/src/ForSyDeIR.hs
+++ b/src/ForSyDeIR.hs
@@ -1,4 +1,15 @@
-module ForSyDeIR where
+module ForSyDeIR
+  ( ActorType (..),
+    IRConstructor (..),
+    IRSignal (..),
+    IRFunction (..),
+    IRSystem (..),
+    prettyIRSignal,
+    prettyIRConstructor,
+    prettyIRFunction,
+    prettyIRSystem,
+  )
+where
 
 import GHC.Core
 import GHC.Core.Ppr (pprCoreBindingWithSize)
@@ -120,24 +131,3 @@ prettyIRSystem (IRSystem (inputs, outputs) constructors signals functions) =
               $$ text "}"
           ]
       )
-
--- Simple example to test ForSyDe IR
-
-exampleSystem :: IRSystem
-exampleSystem =
-  IRSystem
-    (["input"], ["output"])
-    [ IRActor "actor_1" Actor22 "add",
-      IRDelay "delay_1" [0]
-    ]
-    [ IRSignal "s_in" ("input", 1) ("actor_1", 1),
-      IRSignal "s_1" ("actor_1", 1) ("delay_1", 1),
-      IRSignal "s_2" ("delay_1", 1) ("actor_1", 1),
-      IRSignal "s_out" ("actor_1", 1) ("output", 1)
-    ]
-    [ IRFunction "add" Nothing
-    ]
-
-testForSyDeIR :: IO ()
-testForSyDeIR = do
-  putStrLn $ showSDocUnsafe $ prettyIRSystem exampleSystem

--- a/test/ForSyDeIRSpec.hs
+++ b/test/ForSyDeIRSpec.hs
@@ -1,0 +1,49 @@
+module ForSyDeIRSpec (spec) where
+
+import ForSyDeIR
+import GHC.Core
+import GHC.Core.Ppr (pprCoreExpr)
+import GHC.Utils.Outputable
+import Test.Hspec
+
+exampleSystem :: IRSystem
+exampleSystem =
+  IRSystem
+    (["input"], ["output"])
+    [ IRActor "actor_1" Actor22 "add",
+      IRDelay "delay_1" [0]
+    ]
+    [ IRSignal "s_in" ("input", 1) ("actor_1", 1),
+      IRSignal "s_1" ("actor_1", 1) ("delay_1", 1),
+      IRSignal "s_2" ("delay_1", 1) ("actor_1", 1),
+      IRSignal "s_out" ("actor_1", 1) ("output", 1)
+    ]
+    [ IRFunction "add" Nothing
+    ]
+
+-- This is in my opinion horrible, but it seems that multiline strings only
+-- got added in GHC 9.12...
+exampleSystemPretty =
+  "IRSystem (({ input } , { output }) ,\n\
+  \          { IRActor (actor_1 , Actor22 , add),\n\
+  \            IRDelay (delay_1 , [0])\n\
+  \          } ,\n\
+  \          { IRSignal (s_in , (input , 1) , (actor_1 , 1)),\n\
+  \            IRSignal (s_1 , (actor_1 , 1) , (delay_1 , 1)),\n\
+  \            IRSignal (s_2 , (delay_1 , 1) , (actor_1 , 1)),\n\
+  \            IRSignal (s_out , (actor_1 , 1) , (output , 1))\n\
+  \          } ,\n\
+  \          { IRFunction (add ,)\n\
+  \          })"
+
+testForSyDeIR :: IO ()
+testForSyDeIR = do
+  putStrLn $ showSDocUnsafe $ prettyIRSystem exampleSystem
+
+spec :: SpecWith ()
+spec = do
+  describe "IR pretty-printing" $ do
+    it "Test hand-crafted IRSystem" $ do
+      (showSDocUnsafe $ prettyIRSystem exampleSystem) `shouldBe` exampleSystemPretty
+    it "Empty IR-system should not be an empty string" $ do
+      (showSDocUnsafe $ prettyIRSystem $ IRSystem ([], []) [] [] []) `shouldNotBe` ""

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
#46, #47:
This adds testing with Hspec, using hspec-discover. Add testing documentation. Also add a simple test for the existing ForSyDeIR to have a starting point for future tests.

Note that this restructures the `forsyde-devtools.cabal` file quite a bit to avoid duplication. Let me know if I should change something here as I'm very much not an expert with cabal.

#105: I figured I could also resolve this, as I'm updating it for testing anyway.

#144: Now integrated into actions.