### PR TITLE
fix/ForSyDeIR

### DIFF
--- a/docs/forsyde-ir.md
+++ b/docs/forsyde-ir.md
@@ -3,18 +3,20 @@ The ForSyDe IR can be found in the file `src/ForSyDeIR.hs`. The defined data typ
 ```haskell
 data ActorType
   = Actor11
-  | Actor22
-data IRConstructor 
-  = IRDelay String
+  | Actor12
+  ...
+  | Actor44
+data IRConstructor
+  = IRDelay String [Int]
   | IRActor String ActorType String
 data IRSignal = IRSignal String (String, Int) (String, Int)
-data IRFunction = IRFunction String (Maybe CoreExpr)
+data IRFunction = IRFunction String (Maybe CoreBind)
 data IRSystem = IRSystem [IRConstructor] [IRSignal] [IRFunction]
 ```
 
 ## Pretty Printing
 The pretty printing for the ForSyDe IR is also defined under `src/ForSyDeIR.hs`. A summary is provided below. Note that whitespace should be ignored. The pretty printing for `ActorType` is the same as the type it represents.
-- `constructor`: `IRDelay(delayId)`, `IRActor(actorID, actorType, functionId)`
+- `constructor`: `IRDelay(delayId, { tokens })`, `IRActor(actorID, actorType, functionId)`
 - `signal`: `IRSignal(signalId, (sourceId, sourceRate), (targetId, targetRate))`
 - `function`: `IRFunction(functionId, [ function ])`
 - `system`: `IRSystem({ constructors }, { signals }, { functions } )`

--- a/src/ForSyDeIR.hs
+++ b/src/ForSyDeIR.hs
@@ -26,7 +26,7 @@ data ActorType
   deriving (Show)
 
 data IRConstructor
-  = IRDelay String
+  = IRDelay String [Int]
   | IRActor String ActorType String
 
 data IRSignal = IRSignal String (String, Int) (String, Int)
@@ -57,10 +57,13 @@ prettyIRSignal (IRSignal signalId (inputId, inputRate) (outputId, outputRate)) =
       )
 
 prettyIRConstructor :: IRConstructor -> SDoc
-prettyIRConstructor (IRDelay delayId) =
+prettyIRConstructor (IRDelay delayId tokenList) =
   text "IRDelay"
     <+> parens
-      (text delayId)
+      ( text delayId
+          <+> comma
+          <+> text (show tokenList)
+      )
 prettyIRConstructor (IRActor actorId actorType functionId) =
   text "IRActor"
     <+> parens
@@ -112,7 +115,7 @@ exampleSystem :: IRSystem
 exampleSystem =
   IRSystem
     [ IRActor "actor_1" Actor22 "add",
-      IRDelay "delay_1"
+      IRDelay "delay_1" [0]
     ]
     [ IRSignal "s_in" ("input", 1) ("actor_1", 1),
       IRSignal "s_1" ("actor_1", 1) ("delay_1", 1),

--- a/src/ForSyDeIR.hs
+++ b/src/ForSyDeIR.hs
@@ -1,7 +1,7 @@
 module ForSyDeIR where
 
 import GHC.Core
-import GHC.Core.Ppr (pprCoreExpr)
+import GHC.Core.Ppr (pprCoreBindingWithSize)
 import GHC.Utils.Outputable
 
 -- ForSyDe IR data types
@@ -31,7 +31,7 @@ data IRConstructor
 
 data IRSignal = IRSignal String (String, Int) (String, Int)
 
-data IRFunction = IRFunction String (Maybe CoreExpr)
+data IRFunction = IRFunction String (Maybe CoreBind)
 
 data IRSystem = IRSystem [IRConstructor] [IRSignal] [IRFunction]
 
@@ -80,7 +80,7 @@ prettyIRFunction (IRFunction functionId function) =
     <+> parens
       ( text functionId
           <+> comma
-          <+> maybe empty pprCoreExpr function
+          <+> maybe empty pprCoreBindingWithSize function
       )
 
 prettyIRSystem :: IRSystem -> SDoc

--- a/src/ForSyDeIR.hs
+++ b/src/ForSyDeIR.hs
@@ -93,13 +93,15 @@ prettyIRSystem (IRSystem constructors signals functions) =
                 2
                 ( vcat (punctuate comma (map prettyIRConstructor constructors))
                 )
-              $$ text "}",
+              $$ text "}"
+              <+> comma,
             text "{"
               $$ nest
                 2
                 ( vcat (punctuate comma (map prettyIRSignal signals))
                 )
-              $$ text "}",
+              $$ text "}"
+              <+> comma,
             text "{"
               $$ nest
                 2


### PR DESCRIPTION
Fixed IRDelay to include initial tokens as a list of ints. Was not able to correctly update the pretty printing of `IRFunction` expression, will need another update when we have our own pretty printing of the Core IR. Currently using `CoreBind` instead of `CoreExpr` as a temporary fallback.