### PR TITLE
Lock and fix ghc version in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,7 @@
   outputs =
     { flake-utils, ... }@inputs:
     let
+      ghcVersion = "ghc9102";
       overlay = final: prev: {
         haskell = prev.haskell // {
           packageOverrides =
@@ -16,7 +17,7 @@
               forsyde-devtools = hfinal.callCabal2nix "forsyde-devtools" ./. { };
             };
         };
-        forsyde-devtools = final.haskellPackages.forsyde-devtools;
+        forsyde-devtools = final.haskell.packages.${ghcVersion}.forsyde-devtools;
       };
     in
     {
@@ -28,8 +29,11 @@
         pkgs = import inputs.nixpkgs {
           inherit system;
           overlays = [ overlay ];
+          config = {
+            haskell.compiler = pkgs.haskell.compilers.${ghcVersion};
+          };
         };
-        hspkgs = pkgs.haskellPackages;
+        hspkgs = pkgs.haskell.packages.${ghcVersion};
         pypkgs = pkgs.python313Packages;
       in
       {
@@ -41,7 +45,6 @@
             # Haskell specific dev tools
             hspkgs.cabal-install
             hspkgs.haskell-language-server
-            hspkgs.hlint
             hspkgs.ormolu
             # For making mkkdocs site
             pypkgs.mkdocs-material
@@ -49,6 +52,7 @@
             # General dev tools
             pkgs.gnumake
           ];
+          nativeBuildInputs = [ hspkgs.ghc ];
           shellHook = ''
             cp .githooks/* .git/hooks/
             chmod +x .git/hooks/*

--- a/forsyde-devtools.cabal
+++ b/forsyde-devtools.cabal
@@ -16,11 +16,11 @@ common common-options
     default-language: Haskell2010
     build-depends:
         base >=4.6 && <6,
-        ghc == 9.8.4,
+        ghc == 9.10.2,
         ghc-paths == 0.1.0.12,
         forsyde-shallow == 3.5.0.0,
         optparse-applicative >= 0.18.1.0,
-        filepath == 1.4.301.0,
+        filepath == 1.5.4.0,
 
 library
     import:           common-options
@@ -43,7 +43,7 @@ test-suite forsyde-devtools-test
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test
     main-is:          Spec.hs
-    ghc-options:      -threaded -rtsopts -with-rtsopts=-N
+    ghc-options:      -rtsopts -with-rtsopts=-N
     other-modules:
         ForSyDeIRSpec
     build-depends:


### PR DESCRIPTION
Locks and fixes ghc version in nix flake to `9.10.2`, relates to chaos ticket #152. Note that switching from `9.8.4` to `9.10.2` will require redownloading and rebuilding Haskell packages.