### PR TITLE
Fix the pthreads implementation of SDF_example_001

### DIFF
--- a/examples/implementation/SDF_example_001.c
+++ b/examples/implementation/SDF_example_001.c
@@ -139,28 +139,48 @@ static void fifo_get_multiple(struct fifo *fifo, size_t count, element elements[
 }
 
 enum process {
-	ProcessA = 0,
+	Input = 0,
+	ProcessA = 1,
 	ProcessB,
 	ProcessC,
 	ProcessD,
+	Output,
 	End
 };
 
+struct fifo *fifo_in_a;
 struct fifo *fifo_a_b;
 struct fifo *fifo_a_c;
 struct fifo *fifo_b_d;
 struct fifo *fifo_c_d;
+struct fifo *fifo_b_out1;
+struct fifo *fifo_d_out2;
+
+static void *process_input(void *arg)
+{
+	element input[2];
+	int ret;
+
+	fprintf(stderr, "Process Input starting\n");
+	while (!feof(stdin)) {
+		ret = scanf(E_F " " E_F, &input[0], &input[1]);
+		if (ret < 2)
+			break;
+		fifo_put_multiple(fifo_in_a, 2, input);
+	}
+	fprintf(stderr, "Input exiting\n");
+	pthread_exit(NULL);
+}
 
 static void *process_a(void *arg)
 {
-	element input;
+	element input[2];
 
 	fprintf(stderr, "Process A starting\n");
 	while (1) {
-		scanf(E_F, &input);
-		fifo_put_element(fifo_a_b, 2*input);
-		scanf(E_F, &input);
-		fifo_put_element(fifo_a_c, 3*input);
+		fifo_get_multiple(fifo_in_a, 2, input);
+		fifo_put_element(fifo_a_b, 2*input[0]);
+		fifo_put_element(fifo_a_c, 3*input[1]);
 	}
 	pthread_exit(NULL);
 }
@@ -172,7 +192,7 @@ static void *process_b(void *arg)
 	fprintf(stderr, "Process B starting\n");
 	while (1) {
 		fifo_get_element(fifo_a_b, &input);
-		printf("Process B: " E_F "\n", input-2);
+		fifo_put_element(fifo_b_out1, input-2);
 		fifo_put_element(fifo_b_d, input-1);
 	}
 	pthread_exit(NULL);
@@ -199,7 +219,21 @@ static void *process_d(void *arg)
 	while (1) {
 		fifo_get_element(fifo_b_d, &input_b);
 		fifo_get_element(fifo_c_d, &input_c);
-		printf("Process C: " E_F "\n", input_b*input_c);
+		fifo_put_element(fifo_d_out2, input_b*input_c);
+	}
+	pthread_exit(NULL);
+}
+
+static void *process_output(void *arg)
+{
+	element out1;
+	element out2;
+
+	fprintf(stderr, "Process Output starting\n");
+	while (1) {
+		fifo_get_element(fifo_b_out1, &out1);
+		fifo_get_element(fifo_d_out2, &out2);
+		printf("out1: " E_F ", out2: " E_F "\n", out1, out2);
 	}
 	pthread_exit(NULL);
 }
@@ -208,6 +242,9 @@ struct {
 	pthread_t thread;
 	void *(*func)(void *);
 } processes[] = {
+	[Input] = {
+		.func = &process_input,
+	},
 	[ProcessA] = {
 		.func = &process_a,
 	},
@@ -220,6 +257,9 @@ struct {
 	[ProcessD] = {
 		.func = &process_d,
 	},
+	[Output] = {
+		.func = &process_output,
+	},
 	[End] = {},
 };
 
@@ -227,16 +267,23 @@ int main(int argc, char **argv)
 {
 	int ret;
 
+	fifo_in_a = fifo_new(2);
 	fifo_a_b = fifo_new(1);
 	fifo_a_c = fifo_new(1);
 	fifo_b_d = fifo_new(1);
 	fifo_c_d = fifo_new(1);
+	fifo_b_out1 = fifo_new(1);
+	fifo_d_out2 = fifo_new(1);
 
-	for (size_t i = ProcessA; i < End; ++i) {
+	for (size_t i = Input; i < End; ++i) {
 		ret = pthread_create(&processes[i].thread, NULL, processes[i].func, NULL);
 	}
 
+	ret = pthread_join(processes[Input].thread, NULL);
+
 	for (size_t i = ProcessA; i < End; ++i) {
-		ret = pthread_join(processes[i].thread, NULL);
+		ret = pthread_cancel(processes[i].thread);
 	}
+
+	return 0;
 }

--- a/examples/implementation/SDF_example_001.c
+++ b/examples/implementation/SDF_example_001.c
@@ -56,10 +56,8 @@ static void fifo_put_element(struct fifo *fifo, element element)
 {
 	pthread_mutex_lock(&fifo->lock);
 
-	while (fifo->used >= fifo->size) {
-		// fprintf(stderr, "Waiting for space...\n");
+	while (fifo->used >= fifo->size)
 		pthread_cond_wait(&fifo->notfull, &fifo->lock);
-	}
 
 	fifo->elements[fifo->head] = element;
 	fifo->head = (fifo->head + 1) % fifo->size;
@@ -75,10 +73,8 @@ static void fifo_put_multiple(struct fifo *fifo, size_t count, element elements[
 
 	pthread_mutex_lock(&fifo->lock);
 
-	while (fifo->used + count > fifo->size) {
-		// fprintf(stderr, "Waiting for space...\n");
+	while (fifo->used + count > fifo->size)
 		pthread_cond_wait(&fifo->notfull, &fifo->lock);
-	}
 
 	count_a = fifo->head + count <= fifo->size ? count : fifo->size - fifo->head;
 	memcpy(&fifo->elements[fifo->head], &elements[0], sizeof(element)*count);
@@ -99,10 +95,8 @@ static void fifo_get_element(struct fifo *fifo, element *element)
 {
 	pthread_mutex_lock(&fifo->lock);
 
-	while (fifo->used == 0) {
-		// fprintf(stderr, "Waiting for element...\n");
+	while (fifo->used == 0)
 		pthread_cond_wait(&fifo->notempty, &fifo->lock);
-	}
 
 	*element = fifo->elements[fifo->tail];
 	fifo->tail = (fifo->tail + 1) % fifo->size;
@@ -118,10 +112,8 @@ static void fifo_get_multiple(struct fifo *fifo, size_t count, element elements[
 
 	pthread_mutex_lock(&fifo->lock);
 
-	while (fifo->used < count) {
-		// fprintf(stderr, "Waiting for space...\n");
+	while (fifo->used < count)
 		pthread_cond_wait(&fifo->notempty, &fifo->lock);
-	}
 
 	count_a = fifo->tail + count <= fifo->size ? count : fifo->size - fifo->tail;
 	memcpy(&elements[0], &fifo->elements[fifo->tail], sizeof(element)*count);

--- a/examples/implementation/SDF_example_001.c
+++ b/examples/implementation/SDF_example_001.c
@@ -135,7 +135,7 @@ static void fifo_get_multiple(struct fifo *fifo, size_t count, element elements[
 	fifo->used -= count;
 
 	pthread_mutex_unlock(&fifo->lock);
-	pthread_cond_broadcast(&fifo->notempty);
+	pthread_cond_broadcast(&fifo->notfull);
 }
 
 enum process {

--- a/examples/implementation/SDF_example_001.c
+++ b/examples/implementation/SDF_example_001.c
@@ -65,8 +65,8 @@ static void fifo_put_element(struct fifo *fifo, element element)
 	fifo->head = (fifo->head + 1) % fifo->size;
 	++fifo->used;
 
-	pthread_mutex_unlock(&fifo->lock);
 	pthread_cond_broadcast(&fifo->notempty);
+	pthread_mutex_unlock(&fifo->lock);
 }
 
 static void fifo_put_multiple(struct fifo *fifo, size_t count, element elements[count])
@@ -91,8 +91,8 @@ static void fifo_put_multiple(struct fifo *fifo, size_t count, element elements[
 	fifo->head = (fifo->head + count) % fifo->size;
 	fifo->used += count;
 
-	pthread_mutex_unlock(&fifo->lock);
 	pthread_cond_broadcast(&fifo->notempty);
+	pthread_mutex_unlock(&fifo->lock);
 }
 
 static void fifo_get_element(struct fifo *fifo, element *element)
@@ -108,8 +108,8 @@ static void fifo_get_element(struct fifo *fifo, element *element)
 	fifo->tail = (fifo->tail + 1) % fifo->size;
 	--fifo->used;
 
-	pthread_mutex_unlock(&fifo->lock);
 	pthread_cond_broadcast(&fifo->notfull);
+	pthread_mutex_unlock(&fifo->lock);
 }
 
 static void fifo_get_multiple(struct fifo *fifo, size_t count, element elements[count])
@@ -134,8 +134,8 @@ static void fifo_get_multiple(struct fifo *fifo, size_t count, element elements[
 	fifo->tail = (fifo->tail + count) % fifo->size;
 	fifo->used -= count;
 
-	pthread_mutex_unlock(&fifo->lock);
 	pthread_cond_broadcast(&fifo->notfull);
+	pthread_mutex_unlock(&fifo->lock);
 }
 
 enum process {


### PR DESCRIPTION
This is how I would solve the EOF problem and deterministic output order for the pthreads variant (as described in #161).

Additionally I had a typo in `fifo_put_multiple()` which resulted in a deadlock which is also fixed here. But you didn't use the multiple element versions in #161 so you can probably ignore this.

For the pico2 implementation, this would essentially translate into:
1. At the start of the schedule, read all needed input to run this instance to completion
  - If we didn't get enough input, exit at this point
  - This will take a little more memory, but means we won't have too many exit points of the schedule loop, meaning the compiler will be more likely to keep inlining stuff.
2. For multicore, always place all input on the same core, and all output on the same core (in the case we want deterministic input and output order).