### PR TITLE
Update IRConstructors to include local inputs and outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,15 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+
+# ForSyDe DevTools Specific
 *.hcr
-*.irf
 *.fir
+*.pir
+!/examples/test/*.hcr
+!/examples/test/*.fir
+!/examples/test/*.pir
+
 # Ignore build outputs from performing a nix-build or `nix build` command
 result
 result-*

--- a/examples/test/simple.fir
+++ b/examples/test/simple.fir
@@ -1,8 +1,8 @@
 IRSystem(
   {"input"}, {"output"},
   {
-    IRActor("actor_1", Actor22, "add"),
-    IRDelay("delay_1", {0})
+    IRActor("actor_1", Actor22, "add", {"s_in", "s_2"}, {"s_out", "s_1"}),
+    IRDelay("delay_1", {0}, "s_1", "s_2")
   },
   {
     IRSignal("s_in", ("input", 1), ("actor_1", 1)),

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,6 @@
             hspkgs.cabal-install
             hspkgs.haskell-language-server
             hspkgs.ormolu
-            hspkgs.hmatrix
             # For making mkkdocs site
             pypkgs.mkdocs-material
             pypkgs.mkdocs-mermaid2-plugin

--- a/forsyde-devtools.cabal
+++ b/forsyde-devtools.cabal
@@ -44,6 +44,7 @@ executable forsyde-devtools-exe
         Arguments
         CoreIR
         ForSyDeIR
+        CoreToForSyDeIR
 
 test-suite forsyde-devtools-test
     import:           common-options

--- a/forsyde-devtools.cabal
+++ b/forsyde-devtools.cabal
@@ -25,6 +25,7 @@ common common-options
         text == 2.1.2,
         containers == 0.7,
         bytestring == 0.12.2.0,
+        hmatrix == 0.20.2,
 
 library
     import:           common-options

--- a/src/CoreToForSyDeIR.hs
+++ b/src/CoreToForSyDeIR.hs
@@ -182,15 +182,15 @@ getSourceRate context id =
 getRateFromConstructors :: String -> [IRConstructor] -> Int
 getRateFromConstructors id list = case list of
   [] -> error ("No constructor found for id: " ++ id)
-  head : tail -> case head of
-    IRDelay prId _ ->
+  prHead : prTail -> case prHead of
+    IRDelay prId _ (_, _) ->
       if prId == id
         then 1
-        else getRateFromConstructors id tail
-    IRActor prId _ _ ->
+        else getRateFromConstructors id prTail
+    IRActor prId _ _ (_, _) ->
       if prId == id
         then error ("TODO: implement getRateFromConstructors for actors " ++ prId)
-        else getRateFromConstructors id tail
+        else getRateFromConstructors id prTail
 
 -- if prId == id then
 --   let
@@ -247,7 +247,7 @@ createDelaySDF :: TranslationContext -> CoreBndr -> CoreExpr -> TranslationConte
 createDelaySDF context b e =
   let tokens = (getLits e [])
       delayId = showPpr (flags context) b
-      newDelay = IRDelay delayId tokens
+      newDelay = IRDelay delayId tokens ("", "")
    in context {constructors = newDelay : (constructors context)}
 
 getActorSplit :: ActorType -> Int
@@ -266,7 +266,7 @@ createActorSDF context ac b e =
         Just functionName ->
           let (inRates, outRates) = splitAt (getActorSplit ac) lits
               actorId = showPpr (flags context) b
-              newActor = IRActor actorId ac functionName
+              newActor = IRActor actorId ac functionName ([""], [""])
               newActorsList = (actorId, (inRates, outRates)) : (actors context)
            in context {actors = newActorsList, constructors = newActor : (constructors context)}
 

--- a/src/CoreToForSyDeIR.hs
+++ b/src/CoreToForSyDeIR.hs
@@ -6,6 +6,7 @@ import GHC
 import GHC.Core
 import GHC.Driver.Ppr
 import GHC.Types.Literal
+import Prelude hiding (id)
 
 data TranslationContext = TranslationContext
   { flags :: DynFlags,
@@ -76,21 +77,21 @@ translateInputs context e = case e of
 
 translateOutputs :: TranslationContext -> CoreExpr -> TranslationContext
 translateOutputs context e = case e of
-  App ne a -> translateOutputs (translateOutputs context a) ne
+  App e a -> translateOutputs (translateOutputs context a) e
   Var _ -> context
   Type _ -> context
-  Case ne _ _ alts ->
-    let bind = showPpr (flags context) ne
+  Case e _ _ alts ->
+    let bind = showPpr (flags context) e
      in translateAlts context alts
   _ -> error ("translateOutputs: unsupported expression\n" ++ prettyCoreExpr (flags context) e)
 
 translateAlts :: TranslationContext -> [Alt CoreBndr] -> TranslationContext
 translateAlts context alts = case alts of
   [] -> context
-  (Alt _ _ (Var (i))) : tailAlts ->
+  (Alt _ _ (Var (i))) : altTail ->
     let newOutput = showPpr (flags context) i
         newContext = context {systemOutputs = newOutput : (systemOutputs context)}
-     in translateAlts newContext tailAlts
+     in translateAlts newContext altTail
   _ -> error ("translateAlts: AltCon is not supported\n" ++ prettyCoreAltList (flags context) alts)
 
 -- App(App(App(App(Var((,)) * Type(Signal c_a1d4)) * Type(Signal c_a1d4)) *
@@ -107,10 +108,10 @@ translateBinds context binds = translateBindsAux context binds []
 translateBindsAux :: TranslationContext -> [(CoreBndr, CoreExpr)] -> [(String, String)] -> ([(String, String)], TranslationContext)
 translateBindsAux context binds acc = case binds of
   [] -> (acc, context)
-  (b, e) : tailBinds ->
+  (b, e) : bindTail ->
     let outputId = showPpr (flags context) b
         (prId, newContext) = translateBodyExpr context [] e
-     in translateBindsAux newContext tailBinds ((outputId, prId) : acc)
+     in translateBindsAux newContext bindTail ((outputId, prId) : acc)
 
 translateBodyExpr :: TranslationContext -> [String] -> CoreExpr -> (String, TranslationContext)
 translateBodyExpr context arguments e = case e of
@@ -118,9 +119,9 @@ translateBodyExpr context arguments e = case e of
     let prId = showPpr (flags context) i
         newContext = createSignals context prId arguments
      in (prId, newContext)
-  App ne a ->
+  App e a ->
     let (newArguments, newContext) = translateArgument context arguments a
-     in translateBodyExpr newContext newArguments ne
+     in translateBodyExpr newContext newArguments e
   _ -> error ("translateBodyExpr: unsupported expression\n" ++ prettyCoreExpr (flags context) e)
 
 -- App(App(
@@ -136,9 +137,9 @@ translateBodyExpr context arguments e = case e of
 translateArgument :: TranslationContext -> [String] -> CoreExpr -> ([String], TranslationContext)
 translateArgument context arguments e = case e of
   Var i -> let sId = showPpr (flags context) i in (sId : arguments, context)
-  App ne a ->
+  App e a ->
     let (newArguments, newContext) = translateArgument context [] a
-        (prId, newNewContext) = translateBodyExpr newContext newArguments ne
+        (prId, newNewContext) = translateBodyExpr newContext newArguments e
      in (prId : arguments, newNewContext)
   -- Case (Var i) _ _ _ -> let sId = showPpr (flags context) i in (sId : arguments, context)
   _ -> (arguments, context)
@@ -157,14 +158,14 @@ createSignals context pr inputs =
    in createSignalsAux context pr inputs inputRates
 
 createSignalsAux :: TranslationContext -> String -> [String] -> [Int] -> TranslationContext
-createSignalsAux context pr inputs rates = case inputs of
-  [] -> context
-  headInput : tailInputs ->
+createSignalsAux context pr inputs rates = case (inputs, rates) of
+  ([], _) -> context
+  (_, []) -> context
+  (inputHead : inputTail, rateHead : rateTail) ->
     let (newName, newContext) = (genSignalName context)
-        (headRate : tailRates) = rates
-        newSignal = IRSignal newName (headInput, getSourceRate newContext headInput) (pr, headRate)
+        newSignal = IRSignal newName (inputHead, getSourceRate newContext inputHead) (pr, rateHead)
         newNewContext = newContext {signals = newSignal : (signals newContext)}
-     in createSignalsAux newNewContext pr tailInputs tailRates
+     in createSignalsAux newNewContext pr inputTail rateTail
 
 genSignalName :: TranslationContext -> (String, TranslationContext)
 genSignalName context =

--- a/src/CoreToForSyDeIR.hs
+++ b/src/CoreToForSyDeIR.hs
@@ -52,15 +52,13 @@ translateCoreBind context (NonRec b e) = case (showPpr (flags context) b) of
   _ -> translateCoreExpr context b e
 translateCoreBind context (Rec _) = context
 
--- translateCoreBind context (Rec binds) =
-
 translateSystem :: TranslationContext -> CoreExpr -> TranslationContext
-translateSystem context e = case e of
+translateSystem context expr = case expr of
   Lam _ (Lam _ e) -> translateInputs context e
   _ -> context
 
 translateInputs :: TranslationContext -> CoreExpr -> TranslationContext
-translateInputs context e = case e of
+translateInputs context expr = case expr of
   Lam b e ->
     let newInput = showPpr (flags context) b
         newContext = context {systemInputs = newInput : (systemInputs context)}
@@ -73,17 +71,17 @@ translateInputs context e = case e of
         bind = showPpr (flags context) b
         (_, newNewContext) = translateBodyExpr newContext [] e
      in newNewContext
-  _ -> error ("TranslateInputs: unsupported expression\n" ++ prettyCoreExpr (flags context) e)
+  _ -> error ("TranslateInputs: unsupported expression\n" ++ prettyCoreExpr (flags context) expr)
 
 translateOutputs :: TranslationContext -> CoreExpr -> TranslationContext
-translateOutputs context e = case e of
+translateOutputs context expr = case expr of
   App e a -> translateOutputs (translateOutputs context a) e
   Var _ -> context
   Type _ -> context
   Case e _ _ alts ->
     let bind = showPpr (flags context) e
      in translateAlts context alts
-  _ -> error ("translateOutputs: unsupported expression\n" ++ prettyCoreExpr (flags context) e)
+  _ -> error ("translateOutputs: unsupported expression\n" ++ prettyCoreExpr (flags context) expr)
 
 translateAlts :: TranslationContext -> [Alt CoreBndr] -> TranslationContext
 translateAlts context alts = case alts of
@@ -108,13 +106,13 @@ translateBinds context binds = translateBindsAux context binds []
 translateBindsAux :: TranslationContext -> [(CoreBndr, CoreExpr)] -> [(String, String)] -> ([(String, String)], TranslationContext)
 translateBindsAux context binds acc = case binds of
   [] -> (acc, context)
-  (b, e) : bindTail ->
-    let outputId = showPpr (flags context) b
-        (prId, newContext) = translateBodyExpr context [] e
+  (binder, expr) : bindTail ->
+    let outputId = showPpr (flags context) binder
+        (prId, newContext) = translateBodyExpr context [] expr
      in translateBindsAux newContext bindTail ((outputId, prId) : acc)
 
 translateBodyExpr :: TranslationContext -> [String] -> CoreExpr -> (String, TranslationContext)
-translateBodyExpr context arguments e = case e of
+translateBodyExpr context arguments expr = case expr of
   App (App (Var i) _) _ ->
     let prId = showPpr (flags context) i
         newContext = createSignals context prId arguments
@@ -122,29 +120,20 @@ translateBodyExpr context arguments e = case e of
   App e a ->
     let (newArguments, newContext) = translateArgument context arguments a
      in translateBodyExpr newContext newArguments e
-  _ -> error ("translateBodyExpr: unsupported expression\n" ++ prettyCoreExpr (flags context) e)
-
--- App(App(
--- 	App(App(Var(a_1) * Type(d_a1aj)) *  Var($dNum_a1aw))
--- 		 * Var(s_in_a183)) * App(App(App(Var(d_1) * Type(d_a1aj)) * Var($dNum_a1aw)) * Case(Var(ds_d1bd): (wild_00, Signal d_a1aj)
-
--- Let(NonRec(ds_d1fv:
--- 	App(App(App(App(Var(a_1) * Type(d_a1et)) *
--- 	Var(s_in1_a1cK)) *
--- 	Var(s_in2_a1cL)))
+  _ -> error ("translateBodyExpr: unsupported expression\n" ++ prettyCoreExpr (flags context) expr)
 
 -- Returns a list of arguments
 translateArgument :: TranslationContext -> [String] -> CoreExpr -> ([String], TranslationContext)
-translateArgument context arguments e = case e of
-  Var i -> let sId = showPpr (flags context) i in (sId : arguments, context)
+translateArgument context arguments expr = case expr of
+  Var i -> let id = showPpr (flags context) i in (id : arguments, context)
   App e a ->
     let (newArguments, newContext) = translateArgument context [] a
         (prId, newNewContext) = translateBodyExpr newContext newArguments e
      in (prId : arguments, newNewContext)
-  -- Case (Var i) _ _ _ -> let sId = showPpr (flags context) i in (sId : arguments, context)
+  -- Case (Var i) _ _ _ -> let id = showPpr (flags context) i in (id : arguments, context)
   _ -> (arguments, context)
 
--- _ -> error ("translateArgument: unsupported expression\n" ++ prettyCoreExpr e)
+-- _ -> error ("translateArgument: unsupported expression\n" ++ prettyCoreExpr expr)
 
 findRates :: String -> [(String, ([Int], [Int]))] -> Maybe ([Int], [Int])
 findRates actorName list = lookup actorName list
@@ -193,25 +182,6 @@ getRateFromConstructors id list = case list of
         then error ("TODO: implement getRateFromConstructors for actors " ++ prId)
         else getRateFromConstructors id prTail
 
--- if prId == id then
---   let
---     outputRates = case (findRates prId (actors context)) of
---       Just (_, rates) -> rates
---       Nothing -> error "No rates found for actor: " ++ prId
---   in
--- else getRateFromConstructors id tail
-
---   Case e b _ alts ->
--- Let(Rec({(ds_d1bd, App(App(App(App(Var(a_1) * Type(d_a1aj)) *  Var($dNum_a1aw)) * Var(s_in_a183)) * App(App(App(Var(d_1) * Type(d_a1aj)) * Var($dNum_a1aw)) *
-
--- Case(Var(ds_d1bd): (wild_00, Signal d_a1aj)
---  {Alt(DataAlt((,)):
---  {s_out_a1a1, s_1_X1, }Var(s_1_X1)), })))), })
---   let
---     newVar = showPpr (flags context) b
---     newContext = context { variables = newVar : (variables context) }
---   in
-
 -- system s_in = s_out
 --   where
 --     (s_out, s_1) = a_1 s_in (d_1 s_1)
@@ -225,60 +195,60 @@ getRateFromConstructors id list = case list of
 
 --     a_1 context to output with s_out
 
--- -- Case(Var(ds_d1bd): (wild_00, Signal d_a1aj) {
--- --     Alt(DataAlt((,)):
--- -- 	    {s_out_a1a1, s_1_X1, } Var(s_out_a1a1)),
--- --     })
+-- Case(Var(ds_d1bd): (wild_00, Signal d_a1aj) {
+--     Alt(DataAlt((,)):
+-- 	    {s_out_a1a1, s_1_X1, } Var(s_out_a1a1)),
+--     })
 
 translateCoreExpr :: TranslationContext -> CoreBndr -> CoreExpr -> TranslationContext
-translateCoreExpr context b e = case e of
+translateCoreExpr context binder expr = case expr of
   Lam _ (Lam _ (Lam _ (App (App (App (Var (i)) _) _) _))) -> case (showPpr (flags context) i) of
-    "delaySDF" -> createDelaySDF context b e
+    "delaySDF" -> createDelaySDF context binder expr
     _ -> error "expecting delaySDF got something else"
   Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _)))) -> case (showPpr (flags context) i) of
-    "actor22SDF" -> createActorSDF context Actor22 b e
+    "actor22SDF" -> createActorSDF context Actor22 binder expr
     _ -> error "expecting actor22SDF got something else"
   Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _))) -> case (showPpr (flags context) i) of
-    "actor12SDF" -> createActorSDF context Actor12 b e
+    "actor12SDF" -> createActorSDF context Actor12 binder expr
     _ -> error "expecting actor12SDF got something else"
-  _ -> createFunction context b e
+  _ -> createFunction context binder expr
 
 -- delaySDF
 createDelaySDF :: TranslationContext -> CoreBndr -> CoreExpr -> TranslationContext
-createDelaySDF context b e =
-  let tokens = (getLits e [])
-      delayId = showPpr (flags context) b
+createDelaySDF context binder expr =
+  let tokens = (getLits expr [])
+      delayId = showPpr (flags context) binder
       newDelay = IRDelay delayId tokens ("", "")
    in context {constructors = newDelay : (constructors context)}
 
 getActorSplit :: ActorType -> Int
-getActorSplit ac = case ac of
+getActorSplit actorType = case actorType of
   Actor12 -> 1
   Actor22 -> 2
   _ -> error "getActorSplit: unsupported actor type"
 
 -- actorSDF
 createActorSDF :: TranslationContext -> ActorType -> CoreBndr -> CoreExpr -> TranslationContext
-createActorSDF context ac b e =
-  let lits = getLits e []
-      maybeFunctionName = getFunctionName context e
+createActorSDF context actorType binder expr =
+  let lits = getLits expr []
+      maybeFunctionName = getFunctionName context expr
    in case maybeFunctionName of
         Nothing -> error "No function found for actor"
         Just functionName ->
-          let (inRates, outRates) = splitAt (getActorSplit ac) lits
-              actorId = showPpr (flags context) b
-              newActor = IRActor actorId ac functionName ([""], [""])
+          let (inRates, outRates) = splitAt (getActorSplit actorType) lits
+              actorId = showPpr (flags context) binder
+              newActor = IRActor actorId actorType functionName ([""], [""])
               newActorsList = (actorId, (inRates, outRates)) : (actors context)
            in context {actors = newActorsList, constructors = newActor : (constructors context)}
 
 createFunction :: TranslationContext -> CoreBndr -> CoreExpr -> TranslationContext
-createFunction context b e =
-  let functionName = showPpr (flags context) b
-      newFunction = IRFunction functionName (Just e)
+createFunction context binder expr =
+  let functionName = showPpr (flags context) binder
+      newFunction = IRFunction functionName (Just expr)
    in context {functions = newFunction : (functions context)}
 
 getFunctionName :: TranslationContext -> CoreExpr -> Maybe String
-getFunctionName context e = case e of
+getFunctionName context expr = case expr of
   App e a ->
     let getFirst = getFunctionName context a
      in case getFirst of
@@ -295,7 +265,7 @@ getFunctionName context e = case e of
   _ -> Nothing
 
 getLits :: CoreExpr -> [Int] -> [Int]
-getLits e acc = case e of
+getLits expr acc = case expr of
   Lit l -> (fromIntegral (litValue l)) : acc
   App e a -> getLits e (getLits a acc)
   Lam _ e -> getLits e acc

--- a/src/ForSyDeIR.hs
+++ b/src/ForSyDeIR.hs
@@ -43,15 +43,22 @@ data ActorType
   | Actor44
   deriving (Show)
 
+-- IRDelay(delayId, tokens, (inputSignal, outputSignal))
+-- IRActor(actorId, actorType, (inputSignals, outputSignals))
 data IRConstructor
-  = IRDelay String [Int]
-  | IRActor String ActorType String -- ([String], [String])
+  = IRDelay String [Int] (String, String)
+  | IRActor String ActorType String ([String], [String])
 
-data IRSignal = IRSignal String (String, Int) (String, Int) -- IRSignal(signalName (input, sourceRate) (targetId, targetRate))
+-- IRSignal(signalId (sourceId, sourceRate) (targetId, targetRate))
+data IRSignal = IRSignal String (String, Int) (String, Int)
 
+-- IRFunction(functionId, maybe function)
 data IRFunction = IRFunction String (Maybe CoreExpr)
 
+-- IRSystem((globalInputs, globalOutputs), constructors, signals, functions)
 data IRSystem = IRSystem ([String], [String]) [IRConstructor] [IRSignal] [IRFunction]
+
+-- ForSyDe IR pretty printing functions
 
 indent :: String -> String
 indent = unlines . map ("    " ++) . lines
@@ -61,10 +68,21 @@ prettyIRSignal (IRSignal signalId (inputId, inputRate) (outputId, outputRate)) =
   printf "IRSignal(\"%s\", (\"%s\", %d), (\"%s\", %d))" signalId inputId inputRate outputId outputRate
 
 prettyIRConstructor :: IRConstructor -> String
-prettyIRConstructor (IRDelay delayId tokenList) =
-  printf "IRDelay(\"%s\", {%s})" delayId (intercalate ", " (map show tokenList))
-prettyIRConstructor (IRActor actorId actorType functionId) =
-  printf "IRActor(\"%s\", %s, \"%s\")" actorId (show actorType) functionId
+prettyIRConstructor (IRDelay delayId tokens (input, output)) =
+  printf
+    "IRDelay(\"%s\", {%s}, %s, %s)"
+    delayId
+    (intercalate ", " (map show tokens))
+    (show input)
+    (show output)
+prettyIRConstructor (IRActor actorId actorType functionId (inputs, outputs)) =
+  printf
+    "IRActor(\"%s\", %s, \"%s\", {%s}, {%s})"
+    actorId
+    (show actorType)
+    functionId
+    (intercalate ", " (map show inputs))
+    (intercalate ", " (map show outputs))
 
 prettyIRFunction :: DynFlags -> IRFunction -> String
 prettyIRFunction dflags (IRFunction functionId function) =
@@ -80,17 +98,19 @@ prettyIRSystem dflags (IRSystem (inputs, outputs) constructors signals functions
     (indent (intercalate ",\n" (map prettyIRSignal signals)))
     (indent (intercalate ",\n" (map (prettyIRFunction dflags) functions)))
 
+-- ForSyDe IR to JSON functions
+
 instance ToJSON ActorType where
   toJSON a = String $ Text.pack $ show a
 
 instance ToJSON IRConstructor where
-  toJSON (IRDelay name tokens) =
+  toJSON (IRDelay name tokens (_, _)) =
     object
       [ "type" .= Text.pack "Delay",
         "name" .= Text.pack name,
         "tokens" .= Seq.fromList tokens
       ]
-  toJSON (IRActor name ty func) =
+  toJSON (IRActor name ty func (_, _)) =
     object
       [ "type" .= Text.pack (show ty),
         "name" .= Text.pack name,

--- a/src/SDF_schedule.hs
+++ b/src/SDF_schedule.hs
@@ -6,33 +6,37 @@ import Data.List (dropWhile, find, intercalate, nub)
 import Data.Maybe (catMaybes)
 import Data.Ratio (approxRational, denominator, numerator)
 import ForSyDeIR
+import GHC
+import GHC.Data.EnumSet as EnumSet
 import GHC.Generics (Generic)
+import GHC.Paths (libdir)
+import GHC.Plugins
 import GHC.Utils.Outputable
-import Numeric.LinearAlgebra hiding (find)
+import Numeric.LinearAlgebra as LinearAlgebra hiding (find)
 
 -- | Convert ForSyDe IR to SDF data structures
 convertIRSystem :: IRSystem -> ([Actor], [Edge])
 convertIRSystem (IRSystem (inputNames, outputNames) constructors signals _) =
   let -- 1. Delay node names (IRDelay has two parameters)
-      delayNames = [n | IRDelay n _ <- constructors]
+      delayNames = [n | IRDelay n _ (_, _) <- constructors]
 
       -- 2. All actor names (excluding delays)
       allActorNames =
         [ n
-          | IRActor n _ _ <- constructors
+        | IRActor n _ _ (_, _) <- constructors
         ]
 
       -- 3. Actors that receive from "input"
       inputActorNames =
         [ dstId
-          | IRSignal _ (srcId, _) (dstId, _) <- signals,
-            srcId `elem` inputNames
+        | IRSignal _ (srcId, _) (dstId, _) <- signals,
+          srcId `elem` inputNames
         ]
 
       -- 4. Build actor list
       baseActors =
         [ Actor n (n `elem` inputActorNames || n `elem` inputNames)
-          | n <- nub allActorNames
+        | n <- nub allActorNames
         ]
 
       -- 5. Find helper
@@ -50,11 +54,11 @@ convertIRSystem (IRSystem (inputNames, outputNames) constructors signals _) =
             consRate
             False
             0
-          | IRSignal _ (srcId, prodRate) (dstId, consRate) <- signals,
-            srcId `notElem` inputNames,
-            dstId `notElem` outputNames,
-            srcId `notElem` delayNames,
-            dstId `notElem` delayNames
+        | IRSignal _ (srcId, prodRate) (dstId, consRate) <- signals,
+          srcId `notElem` inputNames,
+          dstId `notElem` outputNames,
+          srcId `notElem` delayNames,
+          dstId `notElem` delayNames
         ]
 
       -- 7. Folded delay edges (A -> delay -> B → becomes one edge)
@@ -64,21 +68,21 @@ convertIRSystem (IRSystem (inputNames, outputNames) constructors signals _) =
         let delayConstructor =
               case find
                 ( \c -> case c of
-                    IRDelay name _ -> name == delayName
+                    IRDelay name _ (_, _) -> name == delayName
                     _ -> False
                 )
                 constructors of
-                Just (IRDelay _ initTokens) -> initTokens
+                Just (IRDelay _ initTokens (_, _)) -> initTokens
                 Nothing -> error $ "Delay node " ++ delayName ++ " not found in constructors"
             incoming =
               [ (srcId, prod)
-                | IRSignal _ (srcId, prod) (dstId, _) <- signals,
-                  dstId == delayName
+              | IRSignal _ (srcId, prod) (dstId, _) <- signals,
+                dstId == delayName
               ]
             outgoing =
               [ (dstId, cons)
-                | IRSignal _ (srcId, _) (dstId, cons) <- signals,
-                  srcId == delayName
+              | IRSignal _ (srcId, _) (dstId, cons) <- signals,
+                srcId == delayName
               ]
          in case (incoming, outgoing) of
               ([(srcIn, prodIn)], [(dstOut, consOut)]) ->
@@ -174,7 +178,7 @@ computeNullSpace = nullspace
 --  - Components very close to 0 are treated as 0 by `epsilon` tolerance.
 normalizeToInteger :: Vector Double -> [Integer]
 normalizeToInteger v =
-  let components = toList v
+  let components = LinearAlgebra.toList v
       -- Find the smallest non-zero
       absComponents = map abs components
       nonZero = filter (\x -> x > 1e-12) absComponents
@@ -433,7 +437,7 @@ computeScheduleAndBuffers irSystem =
                       -- Verification
                       repVector = fromIntegral <$> repInt :: [R]
                       verificationResult = mat #> vector repVector
-                      isZeroVector = all (\x -> abs x < 1e-9) (toList verificationResult)
+                      isZeroVector = all (\x -> abs x < 1e-9) (LinearAlgebra.toList verificationResult)
 
                       -- 在这里计算最终结果，这样repInt在作用域内
                       finalResult =
@@ -488,7 +492,7 @@ computeScheduleAndBuffersPrint irSystem = do
           -- Verification: multiply the integer repetition vector back to the topology matrix
           let repVector = fromIntegral <$> repInt :: [R]
               verificationResult = mat #> vector repVector
-              isZeroVector = all (\x -> abs x < 1e-9) (toList verificationResult)
+              isZeroVector = all (\x -> abs x < 1e-9) (LinearAlgebra.toList verificationResult)
 
           putStrLn "\nVerification of null space vector:"
           putStrLn $ "Topology Matrix × Repetition Vector ≈ Zero Vector? " ++ show isZeroVector
@@ -533,8 +537,8 @@ exampleSystem1 :: IRSystem
 exampleSystem1 =
   IRSystem
     (["input"], ["output"])
-    [ IRActor "actor_1" Actor22 "add",
-      IRDelay "delay_1" [0]
+    [ IRActor "actor_1" Actor22 "add" (["s_in", "s_2"], ["s_out", "s_1"]),
+      IRDelay "delay_1" [0] ("s_1", "s_2")
     ]
     [ IRSignal "s_in" ("input", 1) ("actor_1", 1),
       IRSignal "s_1" ("actor_1", 1) ("delay_1", 1),
@@ -549,7 +553,7 @@ exampleSystem2 :: IRSystem
 exampleSystem2 =
   IRSystem
     (["in"], ["out"])
-    [ IRActor "actor" Actor11 "add"
+    [ IRActor "actor" Actor11 "add" (["s_in"], ["s_out"])
     ]
     [ IRSignal "s_in" ("in", 1) ("actor", 1),
       IRSignal "s_out" ("actor", 1) ("out", 1)
@@ -562,9 +566,9 @@ exampleSystem3 :: IRSystem
 exampleSystem3 =
   IRSystem
     (["input"], ["output"])
-    [ IRActor "actor_1" Actor22 "add",
-      IRDelay "delay_1" [0],
-      IRActor "actor_2" Actor11 "add"
+    [ IRActor "actor_1" Actor22 "add" (["s_in", "s_2"], ["s_1", "s_3"]),
+      IRDelay "delay_1" [0] ("s_1", "s_2"),
+      IRActor "actor_2" Actor11 "add" (["s_3"], ["s_out"])
     ]
     [ IRSignal "s_in" ("input", 1) ("actor_1", 1),
       IRSignal "s_1" ("actor_1", 1) ("delay_1", 1),
@@ -580,11 +584,11 @@ exampleSystem4 :: IRSystem
 exampleSystem4 =
   IRSystem
     (["s_ina", "s_inb"], ["s_out"])
-    [ IRActor "actor_a" Actor11 "add",
-      IRActor "actor_b" Actor11 "add",
-      IRActor "actor_c" Actor21 "add",
-      IRActor "actor_d" Actor22 "add",
-      IRDelay "delay" [0]
+    [ IRActor "actor_a" Actor11 "add" (["s_ina"], ["s_1"]),
+      IRActor "actor_b" Actor11 "add" (["s_inb"], ["s_2"]),
+      IRActor "actor_c" Actor21 "add" (["s_1", "s_4"], ["s_3"]),
+      IRActor "actor_d" Actor22 "add" (["s_2", "s_3"], ["s_4_delay", "s_out"]),
+      IRDelay "delay" [0] ("s_4_delay", "s_4")
     ]
     [ IRSignal "s_ina" ("s_ina", 1) ("actor_a", 2),
       IRSignal "s_inb" ("s_inb", 1) ("actor_b", 1),
@@ -602,10 +606,10 @@ exampleSystem5 :: IRSystem
 exampleSystem5 =
   IRSystem
     (["s_in"], ["s_out"])
-    [ IRActor "a" Actor21 "add",
-      IRActor "b" Actor11 "add",
-      IRActor "c" Actor12 "add",
-      IRDelay "delay" [0, 0, 0, 0, 0, 0]
+    [ IRActor "a" Actor21 "add" (["s_in", "s3"], ["s1"]),
+      IRActor "b" Actor11 "add" (["s1"], ["s2"]),
+      IRActor "c" Actor12 "add" (["s2"], ["s3_delay", "s_out"]),
+      IRDelay "delay" [0, 0, 0, 0, 0, 0] ("s3_delay", "s3")
     ]
     [ IRSignal "s_in" ("s_in", 1) ("a", 2),
       IRSignal "s1" ("a", 1) ("b", 2),
@@ -621,11 +625,11 @@ exampleSystem6 :: IRSystem
 exampleSystem6 =
   IRSystem
     (["s_in"], ["s_out"])
-    [ IRActor "a" Actor12 "add",
-      IRActor "b" Actor11 "add",
-      IRActor "c" Actor11 "add",
-      IRActor "d" Actor12 "add",
-      IRDelay "delay" [0, 0]
+    [ IRActor "a" Actor12 "add" (["s_in", "s4"], ["s1"]),
+      IRActor "b" Actor11 "add" (["s1"], ["s2_delay"]),
+      IRActor "c" Actor11 "add" (["s3"], ["s4"]),
+      IRActor "d" Actor12 "add" (["s2"], ["s3", "s_out"]),
+      IRDelay "delay" [0, 0] ("s2_delay", "s2")
     ]
     [ IRSignal "s_in" ("s_in", 1) ("a", 2),
       IRSignal "s1" ("a", 1) ("b", 4),
@@ -642,6 +646,35 @@ exampleSystem6 =
 -- Main
 -- Run all the example Systems
 ----------------------------------------------------------
+customDflags :: IO DynFlags
+customDflags = runGhc (Just libdir) $ do
+  dflags <- getSessionDynFlags
+  return $
+    updOptLevel 2 $
+      dflags
+        { ghcLink = NoLink,
+          ghcMode = CompManager,
+          verbosity = 0,
+          debugLevel = 0,
+          generalFlags =
+            EnumSet.fromList
+              [ Opt_SuppressTicks,
+                Opt_SuppressCoercions,
+                Opt_SuppressCoercionTypes,
+                Opt_SuppressVarKinds,
+                Opt_SuppressModulePrefixes,
+                Opt_SuppressTypeApplications,
+                Opt_SuppressIdInfo,
+                Opt_SuppressUnfoldings,
+                Opt_SuppressTypeSignatures,
+                Opt_SuppressUniques,
+                Opt_SuppressStgExts,
+                Opt_SuppressStgReps,
+                Opt_SuppressTimestamps,
+                Opt_SuppressCoreSizes
+              ]
+        }
+
 main :: IO ()
 main = do
   let examples =
@@ -656,10 +689,11 @@ main = do
   mapM_ runExample examples
   where
     runExample (name, system) = do
+      dflags <- customDflags
       putStrLn $ "========================================================="
       putStrLn $ "Running: " ++ name
       putStrLn $ "========================================================="
-      putStrLn $ showSDocUnsafe $ prettyIRSystem system
+      putStrLn $ prettyIRSystem dflags system
 
       putStrLn "\n--- Detailed analysis ---\n"
       computeScheduleAndBuffersPrint system

--- a/test/ForSyDeIRSpec.hs
+++ b/test/ForSyDeIRSpec.hs
@@ -1,8 +1,8 @@
 module ForSyDeIRSpec (spec) where
 
-import Data.List (dropWhileEnd)
 import Data.Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSC
+import Data.List (dropWhileEnd)
 import ForSyDeIR
 import GHC
 import GHC.Data.EnumSet as EnumSet
@@ -14,8 +14,8 @@ simpleIRSystem :: IRSystem
 simpleIRSystem =
   IRSystem
     (["input"], ["output"])
-    [ IRActor "actor_1" Actor22 "add",
-      IRDelay "delay_1" [0]
+    [ IRActor "actor_1" Actor22 "add" (["s_in", "s_2"], ["s_out", "s_1"]),
+      IRDelay "delay_1" [0] ("s_1", "s_2")
     ]
     [ IRSignal "s_in" ("input", 1) ("actor_1", 1),
       IRSignal "s_1" ("actor_1", 1) ("delay_1", 1),


### PR DESCRIPTION
- Updates ForSyDe IR so process constructors have local inputs and outputs
- Refactors ForSyDe IR testing
- Refactors SDF Scheduling
- Refactors CoreToForSyDeIR
- Cleans up naming and shadowing warning in CoreToForSyDeIR
- Adds CoreToForSyDeIR to cabal

This pull request resolves: #157