### PR TITLE
Add back  `--output-core` as option, and set as default

### DIFF
--- a/src/Arguments.hs
+++ b/src/Arguments.hs
@@ -113,13 +113,12 @@ inputFormatProceduralIR =
         <> help "Input file in Procedural-IR"
     )
 
--- Top-level. All of these 4 flags are optional, but one of them
--- need to be active. Same as inputFormatTop, where the function
--- for FormatCore has InputC as default but InputCore if flag is
--- turned on
+-- Top-level. All of these flags are optional, but one of them
+-- need to be active.
 outputFormatTop :: Parser OutputFormat
 outputFormatTop =
   outputFormatC
+    <|> outputFormatCore
     <|> outputFormatForSyDeIR
     <|> outputFormatForSyDeIRJSON
     <|> outputFormatProceduralIR
@@ -134,19 +133,13 @@ outputFormatC =
         <> help "Output file in C"
     )
 
--- Temporarily commented out, this is how it will work in the end where the
--- Core output format function has C as default if flag is unspecified, and Core
--- if set.
-{-
 outputFormatCore :: Parser OutputFormat
 outputFormatCore =
-  flag
-    OutputC
+  flag'
     OutputCore
     ( long "output-core"
-        <> help "Output file in Core"
+        <> help "Output file in Core (default)"
     )
--}
 
 outputFormatForSyDeIR :: Parser OutputFormat
 outputFormatForSyDeIR =

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -3,10 +3,10 @@ module Main where
 import Arguments
 import CoreIR (compileToCore, prettyCoreProgram)
 import CoreToForSyDeIR
-import ForSyDeIR (prettyIRSystem)
-import Options.Applicative
 import Data.Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSC
+import ForSyDeIR (prettyIRSystem)
+import Options.Applicative
 
 {-
 
@@ -26,15 +26,18 @@ import qualified Data.ByteString.Lazy.Char8 as BSC
           specified, this should be a ForSyDe model (.hs) file
 
     - Output mode:
-        - This should be the format of the output file, if not otherwise
-          specified, this should be C code
-        - if --output-core, output should be in core format
-        - if --output-forsyde-ir, output should be in ForSyDe-IR format
-        - if --output-procedural-ir, output should be in procedural IR format
+        - If --output-c, output file should be in C
+        - If --output-core, output should be in core format
+        - If --output-forsyde-ir, output should be in ForSyDe-IR format
+        - If --output-forsyde-ir-json, output should be in ForSyDe-IR-JSON
+          format
+        - If --output-procedural-ir, output should be in procedural IR format
 
     - Output file argument:
         - Use "-o" flag, outputs to desired file
-        - Dump to stdout if unspecified
+        - Dump to a file "main.xxx" where file format depends on output format
+          flag if unspecified.
+        - If "--stdout", dump to stdout.
 
 -}
 
@@ -71,7 +74,7 @@ run (Arguments (InputFile input_file) output_file OutputForSyDeIR) = do
 run (Arguments (InputFile input_file) output_file OutputForSyDeIRJSON) = do
   (core, dflags) <- compileToCore input_file
   let ir = translateCoreProgram dflags core
-  let ir_json = (BSC.unpack (encode ir))::String
+  let ir_json = (BSC.unpack (encode ir)) :: String
   write_output output_file OutputForSyDeIRJSON ir_json
 run (Arguments (InputFile _) _ OutputProceduralIR) =
   putStrLn "To Procedural IR"


### PR DESCRIPTION
Sebastian was annoyed that while outputting to core was set as default, this option was not possible to invoke. I have figured out how to add it back as a selectable option while keeping it as on by default. Now the help output also looks like:

```
> forsyde-devtools-exe --help
Usage: forsyde-devtools-exe INPUT [(-o|--output OUTPUT) | --stdout] 
                            [--output-c | --output-core | --output-forsyde-ir | 
                              --output-forsyde-ir-json | --output-procedural-ir]

  Compile a ForSyDe model

Available options:
  INPUT                    Input filename
  -o,--output OUTPUT       Output filename
  --stdout                 Print output to stdout
  --output-c               Output file in C
  --output-core            Output file in Core (default)
  --output-forsyde-ir      Output file in ForSyDe-IR
  --output-forsyde-ir-json Output file in ForSyDe-IR-JSON
  --output-procedural-ir   Output file in Procedural-IR
  -h,--help                Show this help text
```

I also changed the "argument spec" big multiline comment at the top of `Main.hs` since it was gloriously outdated