### PR TITLE
examples: Add examples with more actor types such as actor14SDF

### DIFF
--- a/examples/model/SDF_example_006.hs
+++ b/examples/model/SDF_example_006.hs
@@ -1,0 +1,45 @@
+module SDF_example_006 where
+
+import ForSyDe.Shallow
+
+-- Netlist
+system :: Signal Int -> Signal Int
+system s_in = s_out
+  where
+    (s_1, s_2, s_3, s_4) = a_a s_in
+    s_5 = a_b s_1 s_2
+    (s_6, s_7) = a_c s_3
+    s_8 = a_d s_5 s_6
+    s_out = a_e s_8 s_7 s_4
+
+-- Process specifications
+a_a :: Signal Int -> (Signal Int, Signal Int, Signal Int, Signal Int)
+a_a s_1 = actor14SDF 2 (1, 3, 2, 4) f_1 s_1
+
+a_b :: Signal Int -> Signal Int -> Signal Int
+a_b s_1 s_2 = actor21SDF (1, 3) 2 f_2 s_1 s_2
+
+a_c :: Signal Int -> (Signal Int, Signal Int)
+a_c s_1 = actor12SDF 2 (2, 1) f_3 s_1
+
+a_d :: Signal Int -> Signal Int -> Signal Int
+a_d s_1 s_2 = actor21SDF (2, 2) 2 f_4 s_1 s_2
+
+a_e :: Signal Int -> Signal Int -> Signal Int -> Signal Int
+a_e s_1 s_2 s_3 = actor31SDF (2, 1, 4) 1 f_5 s_1 s_2 s_3
+
+-- Function definitions
+f_1 :: [Int] -> ([Int], [Int], [Int], [Int])
+f_1 [x, y] = ([x], [y, x, y + 2], [x + y, x + 1], [x + y + 2, x + 3, y, y + 1])
+
+f_2 :: [Int] -> [Int] -> [Int]
+f_2 [x] [y, z, w] = [x + y + 2, z + w + 1]
+
+f_3 :: [Int] -> ([Int], [Int])
+f_3 [x, y] = ([x + y + 1, x], [x + y + 2])
+
+f_4 :: [Int] -> [Int] -> [Int]
+f_4 [x, y] [z, w] = [x + z, y + w]
+
+f_5 :: [Int] -> [Int] -> [Int] -> [Int]
+f_5 [x, y] [z] [w, v, q, r] = [x + y + z + w + v + q + r]

--- a/examples/model/SDF_example_007.hs
+++ b/examples/model/SDF_example_007.hs
@@ -1,0 +1,38 @@
+module SDF_example_007 where
+
+import ForSyDe.Shallow
+
+-- Netlist
+system :: Signal Int -> Signal Int -> Signal Int
+system s_in_a s_in_b = s_out
+  where
+    (s_1, s_2) = a_a s_in_a
+    (s_3, s_4, s_5) = a_b s_in_b
+    (s_6, s_7) = a_c s_2 s_3 s_4
+    s_out = a_d s_1 s_6 s_7 s_5
+
+-- Process specifications
+a_a :: Signal Int -> (Signal Int, Signal Int)
+a_a s_1 = actor12SDF 2 (2, 1) f_1 s_1
+
+a_b :: Signal Int -> (Signal Int, Signal Int, Signal Int)
+a_b s_1 = actor13SDF 1 (2, 1, 2) f_2 s_1
+
+a_c :: Signal Int -> Signal Int -> Signal Int -> (Signal Int, Signal Int)
+a_c s_1 s_2 s_3 = actor32SDF (2, 4, 2) (2, 2) f_3 s_1 s_2 s_3
+
+a_d :: Signal Int -> Signal Int -> Signal Int -> Signal Int -> Signal Int
+a_d s_1 s_2 s_3 s_4 = actor41SDF (4, 2, 2, 4) 2 f_4 s_1 s_2 s_3 s_4
+
+-- Function definitions
+f_1 :: [Int] -> ([Int], [Int])
+f_1 [x, y] = ([x + y, y], [x])
+
+f_2 :: [Int] -> ([Int], [Int], [Int])
+f_2 [x] = ([x, x + 1], [x], [x + 2, x + 1])
+
+f_3 :: [Int] -> [Int] -> [Int] -> ([Int], [Int])
+f_3 [x, y] [z, v, w, q] [r, t] = ([x + y + v, y], [z + w + q + r + t, z])
+
+f_4 :: [Int] -> [Int] -> [Int] -> [Int] -> [Int]
+f_4 [x, y, z, v] [w, q] [r, t] [u, m, n, o] = [x + y + z + m + n + o + 5, v + w + q + r + t + u + 1]


### PR DESCRIPTION
Since it is not possible to test more complicated actors I added 2 more:

- `model/SDF_example_006.hs` - Has no delays, but contains actors `actor14SDF`, `actor21SDF`, `actor12SDF`, `actor31SDF`. Functions contains only addition.
- `model/SDF_example_007.hs` - Has no delays, but contains actors `actor12SDF`, `actor13SDF`, `actor32SDF`, `actor41SDF`. Functions contains only addition.

In general I think we should start thinking about developing "coverage models" in the form of a table over the example models we have that displays which:

 - actor types
 - if they have delays
 - what functions they have (addition, subtraction, multiplication, division) 

so that it becomes clear what tests we are performing and which models need to be added for it to be possible to work on a specific feature (because obviously it is completely impossible to implement a feature if there is no example model for that in the repo! /s)