### PR TITLE
Core output now has no inlining!

### DIFF
--- a/examples/model/SDF_example_001.hs
+++ b/examples/model/SDF_example_001.hs
@@ -3,6 +3,7 @@ module SDF_example_001 where
 import ForSyDe.Shallow
 
 -- Net list
+system :: Signal Int -> (Signal Int, Signal Int)
 system s_in = (s_out_1, s_out_2)
   where
     (s_1_2, s_1_3) = a_a s_in
@@ -11,19 +12,27 @@ system s_in = (s_out_1, s_out_2)
     s_out_2 = a_d s_2_4 s_3_4
 
 -- Process specifications
+a_a :: Signal Int -> (Signal Int, Signal Int)
 a_a s_in = actor12SDF 2 (1, 1) f_1 s_in
 
+a_b :: Signal Int -> (Signal Int, Signal Int)
 a_b s_in = actor12SDF 1 (1, 1) f_2 s_in
 
+a_c :: Signal Int -> Signal Int
 a_c s_in = actor11SDF 1 1 f_3 s_in
 
+a_d :: Signal Int -> Signal Int -> Signal Int
 a_d s_in_1 s_in_2 = actor21SDF (1, 1) 1 f_4 s_in_1 s_in_2
 
 -- Function definitions
+f_1 :: [Int] -> ([Int], [Int])
 f_1 [x, y] = ([2 * x], [3 * y])
 
+f_2 :: [Int] -> ([Int], [Int])
 f_2 [x] = ([x - 2], [x - 1])
 
+f_3 :: [Int] -> [Int]
 f_3 [x] = [x + 1]
 
+f_4 :: [Int] -> [Int] -> [Int]
 f_4 [x] [y] = [x * y]

--- a/examples/model/SDF_example_002.hs
+++ b/examples/model/SDF_example_002.hs
@@ -3,6 +3,7 @@ module SDF_example_002 where
 import ForSyDe.Shallow
 
 -- Netlist
+system :: Signal Int -> Signal Int -> Signal Int
 system s_in_1 s_in_2 = s_out
   where
     s_1 = a_a s_in_1
@@ -12,21 +13,30 @@ system s_in_1 s_in_2 = s_out
     s_4_delayed = d_1 s_4
 
 -- Process specifications
+a_a :: Signal Int -> Signal Int
 a_a s_1 = actor11SDF 2 1 f_1 s_1
 
+a_b :: Signal Int -> Signal Int
 a_b s_1 = actor11SDF 1 2 f_2 s_1
 
+a_c :: Signal Int -> Signal Int -> Signal Int
 a_c s_1 s_2 = actor21SDF (2, 1) 1 f_3 s_1 s_2
 
+a_d :: Signal Int -> Signal Int -> (Signal Int, Signal Int)
 a_d s_1 s_2 = actor22SDF (2, 1) (2, 1) f_4 s_1 s_2
 
+d_1 :: Signal Int -> Signal Int
 d_1 s = delaySDF [0] s
 
 -- Function definitions
+f_1 :: [Int] -> [Int]
 f_1 [x, y] = [x + y]
 
+f_2 :: [Int] -> [Int]
 f_2 [x] = [x, x + 1]
 
+f_3 :: [Int] -> [Int] -> [Int]
 f_3 [x, y] [z] = [x + y + z]
 
+f_4 :: [Int] -> [Int] -> ([Int], [Int])
 f_4 [x, y] [z] = ([x + y + z], [x + y, x + y + z])

--- a/examples/model/SDF_example_002.hs
+++ b/examples/model/SDF_example_002.hs
@@ -9,7 +9,7 @@ system s_in_1 s_in_2 = s_out
     s_1 = a_a s_in_1
     s_2 = a_b s_in_2
     s_3 = a_c s_1 s_4_delayed
-    (s_out, s_4) = a_d s_2 s_3
+    (s_4, s_out) = a_d s_2 s_3
     s_4_delayed = d_1 s_4
 
 -- Process specifications
@@ -23,7 +23,7 @@ a_c :: Signal Int -> Signal Int -> Signal Int
 a_c s_1 s_2 = actor21SDF (2, 1) 1 f_3 s_1 s_2
 
 a_d :: Signal Int -> Signal Int -> (Signal Int, Signal Int)
-a_d s_1 s_2 = actor22SDF (2, 1) (2, 1) f_4 s_1 s_2
+a_d s_1 s_2 = actor22SDF (2, 1) (1, 2) f_4 s_1 s_2
 
 d_1 :: Signal Int -> Signal Int
 d_1 s = delaySDF [0] s

--- a/examples/model/SDF_example_003.hs
+++ b/examples/model/SDF_example_003.hs
@@ -3,17 +3,21 @@ module SDF_example_003 where
 import ForSyDe.Shallow
 
 -- Net list
+system :: Signal Int -> Signal Int
 system s_in = s_out
   where
     (s_out, s_1) = a_a s_in s_2
     s_2 = d_1 s_1
 
 -- Process specifications
+a_a :: Signal Int -> Signal Int -> (Signal Int, Signal Int)
 a_a s_1 s_2 = actor22SDF (1, 1) (1, 1) add s_1 s_2
 
+d_1 :: Signal Int -> Signal Int
 d_1 s_1 = delaySDF [0] s_1
 
 -- Function definitions
+add :: [Int] -> [Int] -> ([Int], [Int])
 add [x] [y] = ([x + y], [x + y])
 
 -- add_1 [x] = [x + 1]

--- a/examples/model/SDF_example_004.hs
+++ b/examples/model/SDF_example_004.hs
@@ -3,12 +3,15 @@ module SDF_example_004 where
 import ForSyDe.Shallow
 
 -- Net list
+system :: Signal Int -> Signal Int -> (Signal Int, Signal Int)
 system s_in_1 s_in_2 = (s_out_2, s_out_1)
   where
     (s_out_1, s_out_2) = a_a s_in_1 s_in_2
 
 -- Process specifications
+a_a :: Signal Int -> Signal Int -> (Signal Int, Signal Int)
 a_a s_1 s_2 = actor22SDF (1, 1) (1, 1) add s_1 s_2
 
 -- Function definitions
+add :: [Int] -> [Int] -> ([Int], [Int])
 add [x] [y] = ([x + y], [x + y])

--- a/examples/model/SDF_example_005.hs
+++ b/examples/model/SDF_example_005.hs
@@ -3,12 +3,15 @@ module SDF_example_005 where
 import ForSyDe.Shallow
 
 -- Net list
+system :: Signal Int -> (Signal Int, Signal Int)
 system s_in = (s_out_1, s_out_2)
   where
     (s_out_1, s_out_2) = a_a s_in
 
 -- Process specifications
+a_a :: Signal Int -> (Signal Int, Signal Int)
 a_a s_1 = actor12SDF 1 (1, 1) add s_1
 
 -- Function definitions
+add :: [Int] -> ([Int], [Int])
 add [x] = ([x + 1], [x + 2])

--- a/forsyde-devtools.cabal
+++ b/forsyde-devtools.cabal
@@ -55,7 +55,7 @@ executable forsyde-devtools-exe
         CoreIR
         ForSyDeIR
         ProceduralIR
-        CoreToForSyDeIR
+        CoreIRToForSyDeIR
         ProceduralIRToC
         Utilities
 

--- a/forsyde-devtools.cabal
+++ b/forsyde-devtools.cabal
@@ -28,7 +28,7 @@ common common-options
         bytestring >=0.11 && <0.13,
         process == 1.6.25.0,
         hmatrix == 0.20.2,
-        syb == 0.7.3,
+        syb >= 0.7.2.4 && <= 0.7.3,
         lsp == 2.7.0.1,
         network == 3.2.7.0,
         co-log-core == 0.3.2.5,
@@ -66,8 +66,11 @@ executable forsyde-lsp-exe
     ghc-options:      -rtsopts -with-rtsopts=-N
     build-depends:    forsyde-devtools
     other-modules:
-        SKGraphSchema
         ArgumentsLSP
+        ForSyDeIR
+        CoreIRToForSyDeIR
+        SKGraphSchema
+        Utilities
 
 test-suite forsyde-devtools-test
     import:           common-options

--- a/forsyde-devtools.cabal
+++ b/forsyde-devtools.cabal
@@ -67,10 +67,11 @@ executable forsyde-lsp-exe
     build-depends:    forsyde-devtools
     other-modules:
         ArgumentsLSP
+        CoreIR
         ForSyDeIR
         CoreIRToForSyDeIR
-        SKGraphSchema
         Utilities
+        SKGraphSchema
 
 test-suite forsyde-devtools-test
     import:           common-options

--- a/forsyde-devtools.cabal
+++ b/forsyde-devtools.cabal
@@ -28,6 +28,7 @@ common common-options
         bytestring == 0.12.2.0,
         process == 1.6.25.0,
         hmatrix == 0.20.2,
+        syb == 0.7.3,
         lsp == 2.7.0.1,
         network == 3.2.7.0,
         co-log-core == 0.3.2.5,
@@ -52,10 +53,11 @@ executable forsyde-devtools-exe
     other-modules:
         ArgumentsMain
         CoreIR
-        CoreToForSyDeIR
         ForSyDeIR
         ProceduralIR
+        CoreToForSyDeIR
         ProceduralIRToC
+        Utilities
 
 executable forsyde-lsp-exe
     import:           common-options

--- a/forsyde-devtools.cabal
+++ b/forsyde-devtools.cabal
@@ -15,17 +15,17 @@ common common-options
     ghc-options:      -Wall -threaded
     default-language: Haskell2010
     build-depends:
-        base >=4.6 && <6,
+        base >=4.11 && <4.21,
         ghc == 9.10.2,
         ghc-paths == 0.1.0.12,
         forsyde-shallow == 3.5.0.0,
         optparse-applicative >= 0.18.1.0,
-        filepath == 1.5.4.0,
+        filepath >=1 && <1.6,
         aeson == 2.2.3.0,
         aeson-pretty == 0.8.10,
         text == 2.1.2,
         containers == 0.7,
-        bytestring == 0.12.2.0,
+        bytestring >=0.11 && <0.13,
         process == 1.6.25.0,
         hmatrix == 0.20.2,
         syb == 0.7.3,

--- a/src/CoreIR.hs
+++ b/src/CoreIR.hs
@@ -59,8 +59,9 @@ compileToCore filePath = runGhc (Just libdir) $ do
         dflags
           { ghcLink = NoLink,
             ghcMode = CompManager,
+            backend = interpreterBackend,
             verbosity = 0,
-            debugLevel = 0
+            debugLevel = 1
           }
   _ <- setSessionDynFlags newDflags
   target <- guessTarget filePath Nothing Nothing

--- a/src/CoreIR.hs
+++ b/src/CoreIR.hs
@@ -3,11 +3,8 @@ module CoreIR where
 import Data.List (intercalate)
 import GHC
 import GHC.Core
-import GHC.Driver.Main
 import GHC.Driver.Ppr
-import GHC.Paths (libdir)
 import GHC.Plugins
-import System.FilePath (takeBaseName)
 import Text.Printf (printf)
 
 indent :: String -> String
@@ -19,7 +16,7 @@ prettyCoreBind dflags bind = case bind of
   Rec binds -> printf "Rec({\n%s})\n" (indent (intercalate ",\n" (map (prettyBind dflags) binds)))
 
 prettyBind :: DynFlags -> (Var, CoreExpr) -> String
-prettyBind dflags (b, e) = printf "(%s = %s)" (showPpr dflags b) (prettyCoreExpr dflags e)
+prettyBind dflags (b, e) = printf "(%s = \n%s)" (showPpr dflags b) (indent (prettyCoreExpr dflags e))
 
 prettyCoreProgram :: DynFlags -> CoreProgram -> String
 prettyCoreProgram dflags = intercalate "\n" . map (prettyCoreBind dflags)
@@ -34,7 +31,7 @@ prettyCoreExpr dflags expr = case expr of
   Let bind e -> printf "Let(\n%s in\n%s)" (indent (prettyCoreBind dflags bind)) (indent (prettyCoreExpr dflags e))
   Case e b _ alts -> printf "Case(%s of %s {\n%s})" (prettyCoreExpr dflags e) (showPpr dflags b) (indent (prettyCoreAltList dflags alts))
   Cast e co -> printf "Cast(%s by %s)" (prettyCoreExpr dflags e) (showPpr dflags co)
-  Tick t e -> printf "Tick(%s: \n%s)" (showPpr dflags t) (prettyCoreExpr dflags e)
+  Tick t e -> printf "Tick(%s: %s)" (showPpr dflags t) (prettyCoreExpr dflags e)
   Coercion co -> printf "Coercion(%s)" (showPpr dflags co)
 
 prettyCoreAlt :: DynFlags -> CoreAlt -> String
@@ -51,25 +48,3 @@ prettyCoreAltCon dflags altCons = case altCons of
   DataAlt d -> printf "DataAlt(%s)" (showPpr dflags d)
   LitAlt l -> printf "LitAlt(%s)" (showPpr dflags l)
   DEFAULT -> "DEFAULT"
-
-compileToCore :: FilePath -> IO (CoreProgram, DynFlags)
-compileToCore filePath = runGhc (Just libdir) $ do
-  dflags <- getSessionDynFlags
-  let newDflags =
-        dflags
-          { ghcLink = NoLink,
-            ghcMode = CompManager,
-            backend = interpreterBackend,
-            verbosity = 0,
-            debugLevel = 1
-          }
-  _ <- setSessionDynFlags newDflags
-  target <- guessTarget filePath Nothing Nothing
-  setTargets [target]
-  _ <- load LoadAllTargets
-  modSummary <- getModSummary $ mkModuleName (takeBaseName filePath)
-  env <- getSession
-  parsedModule <- liftIO $ hscParse env modSummary
-  (tcg, _) <- liftIO $ hscTypecheckRename env modSummary parsedModule
-  guts <- liftIO $ hscDesugar env modSummary tcg
-  return $ (mg_binds guts, newDflags)

--- a/src/CoreIR.hs
+++ b/src/CoreIR.hs
@@ -3,7 +3,7 @@ module CoreIR where
 import Data.List (intercalate)
 import GHC
 import GHC.Core
-import GHC.Data.EnumSet as EnumSet
+import GHC.Driver.Main
 import GHC.Driver.Ppr
 import GHC.Paths (libdir)
 import GHC.Plugins
@@ -55,37 +55,20 @@ prettyCoreAltCon dflags altCons = case altCons of
 compileToCore :: FilePath -> IO (CoreProgram, DynFlags)
 compileToCore filePath = runGhc (Just libdir) $ do
   dflags <- getSessionDynFlags
-  setSessionDynFlags $
-    updOptLevel 2 $
-      dflags
-        { ghcLink = NoLink,
-          ghcMode = CompManager,
-          verbosity = 0,
-          debugLevel = 0,
-          generalFlags =
-            EnumSet.fromList
-              [ Opt_SuppressTicks,
-                Opt_SuppressCoercions,
-                Opt_SuppressCoercionTypes,
-                Opt_SuppressVarKinds,
-                Opt_SuppressModulePrefixes,
-                Opt_SuppressTypeApplications,
-                Opt_SuppressIdInfo,
-                Opt_SuppressUnfoldings,
-                Opt_SuppressTypeSignatures,
-                Opt_SuppressUniques,
-                Opt_SuppressStgExts,
-                Opt_SuppressStgReps,
-                Opt_SuppressTimestamps,
-                Opt_SuppressCoreSizes
-              ]
-        }
-  newDflags <- getSessionDynFlags
+  let newDflags =
+        dflags
+          { ghcLink = NoLink,
+            ghcMode = CompManager,
+            verbosity = 0,
+            debugLevel = 0
+          }
+  _ <- setSessionDynFlags newDflags
   target <- guessTarget filePath Nothing Nothing
   setTargets [target]
   _ <- load LoadAllTargets
   modSummary <- getModSummary $ mkModuleName (takeBaseName filePath)
-  parse <- parseModule modSummary
-  typecheck <- typecheckModule parse
-  desugar <- desugarModule typecheck
-  return $ (mg_binds . dm_core_module $ desugar, newDflags)
+  env <- getSession
+  parsedModule <- liftIO $ hscParse env modSummary
+  (tcg, _) <- liftIO $ hscTypecheckRename env modSummary parsedModule
+  guts <- liftIO $ hscDesugar env modSummary tcg
+  return $ (mg_binds guts, newDflags)

--- a/src/CoreIRToForSyDeIR.hs
+++ b/src/CoreIRToForSyDeIR.hs
@@ -94,13 +94,18 @@ translateSystem initialContext expr = case expr of
 
 -- | Identifies the system outputs of the net list and does the final clean-up
 -- of the `TranslationContext` by updating constructors and signals.
+--
+-- NOTE: This function needs to be updated with new pattern matches for
+-- translation to support net lists with additional system ouputs.
 translateSystemOutputs :: TranslationContext -> CoreExpr -> TranslationContext
 translateSystemOutputs initialContext expr = case expr of
+  -- System has 1 output
   Var out ->
     let context1 = updateSystemOutput initialContext out
         context2 = context1 {systemInputs = reverse (systemInputs context1)}
         context3 = updateConstructorsAndSignals context2
      in context3
+  -- System has 2 outputs
   App (App (App (App (Var _) (Type _)) (Type _)) (Var out1)) (Var out2) ->
     let context1 = foldl updateSystemOutput initialContext [out1, out2]
         context2 =
@@ -201,17 +206,17 @@ translateSystemBinds initialContext binds = case binds of
 -- potentially updated `TranslationContext`.
 --
 -- NOTE: This function needs to be updated with new pattern matches for
--- translation to support additional process constructors.
+-- translation to support process constructors with more inputs.
 translateSystemExpr :: TranslationContext -> CoreExpr -> (Binder, TranslationContext)
 translateSystemExpr initialContext expr = case expr of
-  -- delaySDF
+  -- Application of process constructors with 1 input
   App (Var i) (Var a) ->
     let pcId = showPpr (flags initialContext) i
         aId = showPpr (flags initialContext) a
         arguments = [(aId)]
         context1 = createSignals initialContext pcId arguments
      in (PcId pcId, context1)
-  -- actor22SDF
+  -- Application of process constructors with 2 input
   App (App (Var i) (Var a1)) (Var a2) ->
     let pcId = showPpr (flags initialContext) i
         a1Id = showPpr (flags initialContext) a1
@@ -307,6 +312,9 @@ getSourceFromArgument context id =
 -- inputs to the top level function, represented by `Lam`, and inputs to the
 -- process constructor, represented by `App`. If it cannot match an actor or
 -- delay then it creates a function.
+--
+-- NOTE: This function needs to be updated with new pattern matches for
+-- translation to support additional process constructors.
 translateCoreExpr :: TranslationContext -> CoreBndr -> CoreExpr -> TranslationContext
 translateCoreExpr context binder expr = case expr of
   Lam _ (App (App (App (Var (i)) _) _) _) ->

--- a/src/CoreIRToForSyDeIR.hs
+++ b/src/CoreIRToForSyDeIR.hs
@@ -22,8 +22,18 @@ data TranslationContext = TranslationContext
     systemOutputs :: [String], -- List of global outputs to net list
     nameCounter :: Int, -- Counter used for naming signals
     pcRates :: [(String, ([Int], [Int]))], -- Associated list of pcIds and input and ouput rates
-    bindings :: [(String, String)] -- Associated list of binderIds and pcIds
+    binders :: [(String, Binder)] -- Associated list of binderIds and Binders
   }
+
+-- | `Binder` is a data type used to represent what a `CoreBndr` is associated
+-- to. Can either directly represent a process constructor through `PcId` or
+-- indirectly represent a process constructor through `Binding` with a
+-- bindingId and index. Note that in the case of a `Binding` the bindingId is
+-- associated with a multi-output process constructor and the index identifies
+-- a specific output.
+data Binder
+  = PcId String
+  | Binding String Int
 
 initialTranslationContext :: DynFlags -> TranslationContext
 initialTranslationContext dflags =
@@ -36,47 +46,22 @@ initialTranslationContext dflags =
       systemOutputs = [],
       nameCounter = 1,
       pcRates = [],
-      bindings = []
+      binders = []
     }
 
 -- | Translates a `CoreProgram` into an `IRSystem` requires `DynFlags` to
--- safely convert GHC Core elements into strings. Starts within an empty
+-- safely convert GHC Core elements into strings. Starts with an empty
 -- `TranslationContext`.
 translateCoreProgram :: DynFlags -> CoreProgram -> IRSystem
 translateCoreProgram dflags program =
-  let finalContext = finaliseConstructors (foldl translateCoreBind (initialTranslationContext dflags) program)
+  let finalContext = foldl translateCoreBind (initialTranslationContext dflags) program
    in IRSystem
         (systemInputs finalContext, systemOutputs finalContext)
         (map snd (constructors finalContext))
         (map snd (signals finalContext))
         (map snd (functions finalContext))
 
-finaliseConstructors :: TranslationContext -> TranslationContext
-finaliseConstructors context = context {constructors = aux (map snd (signals context)) (constructors context)}
-  where
-    aux :: [IRSignal] -> [(String, IRConstructor)] -> [(String, IRConstructor)]
-    aux currentSignals currentConstructors = case currentSignals of
-      [] -> currentConstructors
-      (IRSignal signalId (sourceId, _) (targetId, _)) : signalTail ->
-        let newConstructors = map (updateConstructor signalId sourceId targetId) currentConstructors
-         in aux signalTail newConstructors
-    updateConstructor :: String -> String -> String -> (String, IRConstructor) -> (String, IRConstructor)
-    updateConstructor signalId sourceId targetId (constructorId, constructor) = case constructor of
-      IRDelay pcId tokens (inputSignal, outputSignal) ->
-        if pcId == sourceId
-          then (constructorId, IRDelay pcId tokens (inputSignal, signalId))
-          else
-            if pcId == targetId
-              then (constructorId, IRDelay pcId tokens (signalId, outputSignal))
-              else (constructorId, constructor)
-      IRActor pcId actorType functionId (inputSignals, outputSignals) ->
-        if pcId == sourceId
-          then (constructorId, IRActor pcId actorType functionId (inputSignals, signalId : outputSignals))
-          else
-            if pcId == targetId
-              then (constructorId, IRActor pcId actorType functionId (signalId : inputSignals, outputSignals))
-              else (constructorId, constructor)
-
+-- | Translates a top level `CoreBind`. Module information is currently ignored.
 translateCoreBind :: TranslationContext -> CoreBind -> TranslationContext
 translateCoreBind context (NonRec b e) = case (showPpr (flags context) b) of
   "$trModule" -> context
@@ -86,247 +71,250 @@ translateCoreBind context (NonRec b e) = case (showPpr (flags context) b) of
 -- output, thus unsure what the expected outcome should be.
 translateCoreBind _ (Rec _) = error "translateCoreBind: `Rec` used in top level of Core output"
 
+-- | Translates the `CoreExpr` which is associated with the system net list.
+-- Identifies system inputs, builds the net list through a `TranslationContext`,
+-- and identifies system outputs.
 translateSystem :: TranslationContext -> CoreExpr -> TranslationContext
-translateSystem context expr = case expr of
-  -- Skips the first two `Lam` as they relate to type information
-  Lam _ (Lam _ e) -> translateInputs context e
-  _ -> context
-
-translateInputs :: TranslationContext -> CoreExpr -> TranslationContext
-translateInputs context expr = case expr of
+translateSystem initialContext expr = case expr of
   Lam b e ->
-    let newInput = showPpr (flags context) b
-        newContext = context {systemInputs = newInput : (systemInputs context)}
-     in translateInputs newContext e
+    let newInput = showPpr (flags initialContext) b
+        context1 = initialContext {systemInputs = newInput : (systemInputs initialContext)}
+        context2 = translateSystem context1 e
+     in context2
   Let (Rec binds) out ->
-    let newContext = translateOutputs context out
-        newNewContext = translateBinds newContext binds
-     in updateSignals newNewContext
+    let context1 = translateSystemBinds initialContext binds
+        context2 = translateSystem context1 out
+     in context2
   Let (NonRec b e) out ->
-    let newContext = translateOutputs context out
-        binderId = showPpr (flags newContext) b
-        (pcId, newNewContext) = translateBodyExpr newContext [] e
-        newNewNewContext = newNewContext {bindings = (binderId, pcId) : (bindings newNewContext)}
-     in updateSignals newNewNewContext
-  Tick _ e -> translateInputs context e
-  _ -> error ("translateInputs: unsupported expression\n" ++ prettyCoreExpr (flags context) expr)
+    -- A `NonRec` can just be translated as a single bind
+    let context1 = translateSystemBinds initialContext [(b, e)]
+        context2 = translateSystem context1 out
+     in context2
+  _ -> translateSystemOutputs initialContext expr
+
+-- | Identifies the system outputs of the net list and does the final clean-up
+-- of the `TranslationContext` by updating constructors and signals.
+translateSystemOutputs :: TranslationContext -> CoreExpr -> TranslationContext
+translateSystemOutputs initialContext expr = case expr of
+  Var i ->
+    let outputId = showPpr (flags initialContext) i
+        (sourceId, sourceRate) = getSourceFromArgument initialContext outputId
+        newSignal = IRSignal outputId (sourceId, sourceRate) (outputId, 1)
+        context2 =
+          initialContext
+            { systemOutputs = outputId : (systemOutputs initialContext),
+              signals = (outputId, newSignal) : (signals initialContext)
+            }
+        context3 = updateConstructorsAndSignals context2
+     in context3
+  _ -> error ("translateSystemOutputs: unsupported expression\n" ++ prettyCoreExpr (flags initialContext) expr)
 
 -- | Updates all the signals within `TranslationContext` which are temporarily
--- using a binderId as either a sourceid or targetId. Replaces them with their
--- associated pcId based on the bindings accumulated within the
--- `TranslationContext`.
-updateSignals :: TranslationContext -> TranslationContext
-updateSignals context =
-  let newSignals = map (updateSignal) (signals context)
-   in context {signals = newSignals}
+-- using a binder as the signal source. Replaces them with their associated
+-- process constructor based on the binders accumulated within the
+-- `TranslationContext`. Also updates the outputs of the associated process
+-- constructors. Since if its a source of to signal the signal is an output.
+updateConstructorsAndSignals :: TranslationContext -> TranslationContext
+updateConstructorsAndSignals initialContext =
+  let initialSignals = map snd (signals initialContext)
+      context1 = aux initialContext initialSignals []
+   in context1
   where
-    updateSignal :: (String, IRSignal) -> (String, IRSignal)
-    updateSignal (currentSignalId, currentSignal) = case currentSignal of
-      IRSignal signalId (sourceId, sourceRate) (targetId, targetRate) ->
-        case getIdFromBinder sourceId (bindings context) of
-          Nothing -> case getIdFromBinder targetId (bindings context) of
-            Nothing -> (currentSignalId, currentSignal)
-            Just pcId ->
-              let inputRates = case (lookup pcId (pcRates context)) of
-                    Just (rates, _) -> rates
-                    Nothing -> error ("No rates found for actor: " ++ pcId)
-                  newSignal = IRSignal signalId (sourceId, sourceRate) (pcId, inputRates !! targetRate)
-               in (currentSignalId, newSignal)
-          Just pcId ->
-            let outputRates = case (lookup pcId (pcRates context)) of
-                  Just (_, rates) -> rates
-                  Nothing -> error ("No rates found for actor: " ++ pcId)
-                newSignal = IRSignal signalId (pcId, outputRates !! sourceRate) (targetId, targetRate)
-             in (currentSignalId, newSignal)
+    aux :: TranslationContext -> [IRSignal] -> [(String, IRSignal)] -> TranslationContext
+    aux currentContext currentSignals acc = case currentSignals of
+      [] ->
+        let context1 = currentContext {signals = acc}
+         in context1
+      currentSignal@(IRSignal signalId (sourceId, sourceRate) (targetId, targetRate)) : signalsTail ->
+        let maybebinder = lookup sourceId (binders currentContext)
+         in case maybebinder of
+              Just associatedbinder -> case associatedbinder of
+                PcId pcId ->
+                  -- Signal source was a temporary binder, sourceRate represents
+                  -- the index of the output rather than a rate
+                  let outputRates = case (lookup pcId (pcRates currentContext)) of
+                        Just (_, rates) -> rates
+                        Nothing -> error ("updateSignals - No rates found for actor: " ++ pcId)
+                      newSignal = IRSignal signalId (pcId, outputRates !! sourceRate) (targetId, targetRate)
+                      context1 = updateConstructorsOutputs currentContext signalId pcId sourceRate
+                   in aux context1 signalsTail ((signalId, newSignal) : acc)
+                _ -> error ("updateSignals - binder is not associated with any process constructors")
+              Nothing ->
+                -- Signal source was already a process constructor meaning it
+                -- only had 1 output, thus passing index zero
+                let context1 = updateConstructorsOutputs currentContext signalId sourceId 0
+                 in aux context1 signalsTail ((signalId, currentSignal) : acc)
 
--- | Helper function for `updateSignals` which returns pcId for inputed binderId
-getIdFromBinder :: String -> [(String, String)] -> Maybe String
-getIdFromBinder targetBinder binds = case binds of
-  [] -> Nothing
-  (binder, pcId) : bindTail ->
-    if targetBinder == binder
-      then Just pcId
-      else getIdFromBinder targetBinder bindTail
+-- | Updates the outputs constructors within `TranslationContext`. It adds a
+-- signal to the output list of a specific process constructor at the specified
+-- index
+updateConstructorsOutputs :: TranslationContext -> String -> String -> Int -> TranslationContext
+updateConstructorsOutputs initialContext signalId pcId index =
+  let newConstructors = map (updateConstructor) (constructors initialContext)
+      context1 = initialContext {constructors = newConstructors}
+   in context1
+  where
+    updateConstructor :: (String, IRConstructor) -> (String, IRConstructor)
+    updateConstructor (currentPcId, currentConstructor) =
+      if pcId == currentPcId
+        then case currentConstructor of
+          IRDelay _ tokens (inputSignal, _) ->
+            if index /= 0
+              then error ("updateConstructorsOutputs - pcId matches a delay but has a non-zero index")
+              else
+                let newConstructor = IRDelay currentPcId tokens (inputSignal, signalId)
+                 in (currentPcId, newConstructor)
+          IRActor _ actorType functionId (inputSignals, outputSignals) ->
+            let newOutputSignals = take index outputSignals ++ [signalId] ++ drop (index + 1) outputSignals
+                newConstructor = IRActor currentPcId actorType functionId (inputSignals, newOutputSignals)
+             in (currentPcId, newConstructor)
+        else (currentPcId, currentConstructor)
 
-translateOutputs :: TranslationContext -> CoreExpr -> TranslationContext
-translateOutputs context expr = case expr of
-  App e a -> translateOutputs (translateOutputs context a) e
-  Var _ -> context
-  Type _ -> context
-  Case e _ _ alts -> case getVarFromAlts context alts of
-    (_, Nothing) -> context
-    (binder, Just index) ->
-      let bind = showPpr (flags context) e
-          (name, newContext) = genSignalName context
-          newSignal = IRSignal name (bind, index) (binder, 1)
-       in newContext {systemOutputs = binder : (systemOutputs newContext), signals = (name, newSignal) : (signals newContext)}
-  Let (NonRec b e) a ->
-    let newContext = translateOutputs context a
-        binderId = showPpr (flags newContext) b
-        (pcId, newNewContext) = translateBodyExpr newContext [] e
-     in newNewContext {bindings = (binderId, pcId) : (bindings newNewContext)}
-  Tick _ e -> translateOutputs context e
-  _ -> error ("translateOutputs: unsupported expression\n" ++ prettyCoreExpr (flags context) expr)
+-- | Translates system binds and adds identified binders to `TranslationContext`
+translateSystemBinds :: TranslationContext -> [(CoreBndr, CoreExpr)] -> (TranslationContext)
+translateSystemBinds initialContext binds = case binds of
+  [] -> (initialContext)
+  (b, e) : bindTail ->
+    let binderId = showPpr (flags initialContext) b
+        (binder, context1) = translateSystemExpr initialContext e
+        context2 = context1 {binders = (binderId, binder) : (binders context1)}
+     in translateSystemBinds context2 bindTail
 
--- | Helper function for `translateOutputs` which identifies variable chosen by
--- an `AltCon` of a `Case`. Returns the  identified variable as a string and its
--- index as an optional int.
-getVarFromAlts :: TranslationContext -> [Alt CoreBndr] -> (String, Maybe Int)
-getVarFromAlts context alts = case alts of
-  [] -> error ("getIndexFromAlts: empty AltCon list")
-  (Alt _ binds (Var (i))) : [] ->
-    let binder = showPpr (flags context) i
-        index = elemIndex (i) (binds)
-     in (binder, index)
-  _ -> error ("getIndexFromAlts: more than one AltCon\n" ++ prettyCoreAltList (flags context) alts)
-
-translateBinds :: TranslationContext -> [(CoreBndr, CoreExpr)] -> (TranslationContext)
-translateBinds context binds = case binds of
-  [] -> (context)
-  (binder, expr) : bindTail ->
-    let binderId = showPpr (flags context) binder
-        (pcId, newContext) = translateBodyExpr context [] expr
-        newNewContext = newContext {bindings = (binderId, pcId) : (bindings newContext)}
-     in translateBinds newNewContext bindTail
-
-translateBodyExpr :: TranslationContext -> [(String, Maybe Int)] -> CoreExpr -> (String, TranslationContext)
-translateBodyExpr context arguments expr = case expr of
-  App (App (Var i) _) _ ->
-    let pcId = showPpr (flags context) i
-        newContext = createSignals context pcId arguments
-     in (pcId, newContext)
-  App e a ->
-    let (newArguments, newContext) = translateArgument context arguments a
-     in translateBodyExpr newContext newArguments e
-  -- Case (Var i) _ _ alts ->
-  --   let binder = showPpr (flags context) i
-  --       index = getIndexFromAlts context alts
-  --    in ((binder, index) : arguments, context)
-  Tick _ e -> translateBodyExpr context arguments e
-  _ -> error ("translateBodyExpr: unsupported expression\n" ++ prettyCoreExpr (flags context) expr)
-
--- Returns a list of arguments
-translateArgument :: TranslationContext -> [(String, Maybe Int)] -> CoreExpr -> ([(String, Maybe Int)], TranslationContext)
-translateArgument context arguments expr = case expr of
-  Var i -> let id = showPpr (flags context) i in ((id, Nothing) : arguments, context)
-  App e a ->
-    let (newArguments, newContext) = translateArgument context [] a
-        (pcId, newNewContext) = translateBodyExpr newContext newArguments e
-     in ((pcId, Nothing) : arguments, newNewContext)
+-- | Translates system `CoreExpr`. Identifies if the expression represents an
+-- application of a process constructor or connection to a specific output of a
+-- process constructor. In either case returns a `Binder` along side a
+-- potentially updated `TranslationContext`.
+--
+-- NOTE: This function needs to be updated with new pattern matches for
+-- translation to support additional process constructors.
+translateSystemExpr :: TranslationContext -> CoreExpr -> (Binder, TranslationContext)
+translateSystemExpr initialContext expr = case expr of
+  -- delaySDF
+  App (Var i) (Var a) ->
+    let pcId = showPpr (flags initialContext) i
+        aId = showPpr (flags initialContext) a
+        arguments = [(aId)]
+        context1 = createSignals initialContext pcId arguments
+     in (PcId pcId, context1)
+  -- actor22SDF
+  App (App (Var i) (Var a1)) (Var a2) ->
+    let pcId = showPpr (flags initialContext) i
+        a1Id = showPpr (flags initialContext) a1
+        a2Id = showPpr (flags initialContext) a2
+        arguments = [(a2Id), (a1Id)]
+        context1 = createSignals initialContext pcId arguments
+     in (PcId pcId, context1)
   Case (Var i) _ _ alts ->
-    let binder = showPpr (flags context) i
-        index = getIndexFromAlts context alts
-     in ((binder, index) : arguments, context)
-  Tick _ e -> translateArgument context arguments e
-  _ -> error ("translateArgument: unsupported expression\n" ++ prettyCoreExpr (flags context) expr)
+    let bindingId = showPpr (flags initialContext) i
+        index = getIndexFromAlts initialContext alts
+     in ((Binding bindingId index), initialContext)
+  _ -> error ("translateSystemExpr - unsupported CoreExpr:\n" ++ prettyCoreExpr (flags initialContext) expr)
 
-getIndexFromAlts :: TranslationContext -> [Alt CoreBndr] -> (Maybe Int)
+-- | Helper function which identifies the id chosen by an `AltCon` for a `Case`.
+-- Returns the index of the identified id from a list of ids. These ids
+-- represent the outputs of a process constructor.
+getIndexFromAlts :: TranslationContext -> [Alt CoreBndr] -> Int
 getIndexFromAlts context alts = case alts of
-  [] -> error ("getIndexFromAlts: empty AltCon list")
-  (Alt _ binds (Var (i))) : [] -> elemIndex (i) (binds)
-  _ -> error ("getIndexFromAlts: more than one AltCon\n" ++ prettyCoreAltList (flags context) alts)
+  [] -> error ("getIndexFromAlts - empty AltCon list")
+  (Alt _ ids (Var (i))) : [] ->
+    let maybeIndex = elemIndex i ids
+     in case maybeIndex of
+          Just index -> index
+          Nothing -> error ("getIndexFromAlts - unable to find: " ++ showPpr (flags context) i)
+  _ -> error ("getIndexFromAlts - more than one AltCon:\n" ++ prettyCoreAltList (flags context) alts)
 
 -- | Creates signals based on the arguments of a process constructor. All
 -- signals created with this function have the process constructor as the
 -- target.
-createSignals :: TranslationContext -> String -> [(String, Maybe Int)] -> TranslationContext
-createSignals context pr arguments =
+createSignals :: TranslationContext -> String -> [(String)] -> TranslationContext
+createSignals context pcId arguments =
   -- The input rates of the process constructor are used to determine the
   -- targetRate of created signals, the index for the input is the same as the
   -- current arguments index.
-  let inputRates = case (lookup pr (pcRates context)) of
+  let inputRates = case (lookup pcId (pcRates context)) of
         Just (rates, _) -> rates
-        Nothing -> error ("No rates found for actor: " ++ pr)
-   in aux context pr arguments inputRates
+        Nothing -> error ("createSignals - No rates found for actor: " ++ pcId)
+   in aux context arguments inputRates
   where
-    aux :: TranslationContext -> String -> [(String, Maybe Int)] -> [Int] -> TranslationContext
-    aux currentContext currentPr currentArguments rates = case (currentArguments, rates) of
+    aux :: TranslationContext -> [(String)] -> [Int] -> TranslationContext
+    aux currentContext currentArguments rates = case (currentArguments, rates) of
       ([], _) -> currentContext
       (_, []) -> currentContext
-      ((inputHead, Just i) : inputTail, rateHead : rateTail) ->
-        -- The optional int indicates the inputHead represents a binder rather
-        -- than a process constructor. The optional int is the index for the
-        -- output. Both binder and index will be replaced using the
-        -- `updateSignals` function.
-        let (name, newContext) = (genSignalName currentContext)
-            newSignal = IRSignal name (inputHead, i) (currentPr, rateHead)
-            newNewContext = newContext {signals = (name, newSignal) : (signals newContext)}
-         in aux newNewContext currentPr inputTail rateTail
-      ((inputHead, Nothing) : inputTail, rateHead : rateTail) ->
-        let (name, newContext) = (genSignalName currentContext)
-            newSignal = IRSignal name (inputHead, getSourceRate newContext inputHead) (currentPr, rateHead)
-            newNewContext = newContext {signals = (name, newSignal) : (signals newContext)}
-         in aux newNewContext currentPr inputTail rateTail
+      (argumentsHead : argumentsTail, ratesHead : ratesTail) ->
+        let (sourceId, sourceRate) = getSourceFromArgument currentContext argumentsHead
+            newSignal = IRSignal argumentsHead (sourceId, sourceRate) (pcId, ratesHead)
+            context1 = currentContext {signals = (argumentsHead, newSignal) : (signals currentContext)}
+            context2 = updateConstructorsInputs context1 pcId argumentsHead
+         in aux context2 argumentsTail ratesTail
 
-genSignalName :: TranslationContext -> (String, TranslationContext)
-genSignalName context =
-  let counter = nameCounter context
-      newName = "s_" ++ show counter
-      newContext = context {nameCounter = counter + 1}
-   in (newName, newContext)
-
--- | Helper function for `createSignals` which gets the output rate for the
--- source of a signal. If the id is associated with a global input or delay
--- then the returned output rate is 1.
-getSourceRate :: TranslationContext -> String -> Int
-getSourceRate context id =
-  if elem id (systemInputs context)
-    then 1
-    else aux (map snd (constructors context))
+-- | Updates the inputs of constructors within a `TranslationContext`. Adds a
+-- signal to the head of a process constructors input signals list.
+updateConstructorsInputs :: TranslationContext -> String -> String -> TranslationContext
+updateConstructorsInputs initialContext pcId signalId =
+  let newConstructors = map (updateConstructor) (constructors initialContext)
+      context1 = initialContext {constructors = newConstructors}
+   in context1
   where
-    aux :: [IRConstructor] -> Int
-    aux list = case list of
-      [] -> error ("getSourceRate: " ++ id ++ " not in a valid constructor")
-      pcHead : pcTail -> case pcHead of
-        IRDelay pcId _ (_, _) ->
-          if pcId == id
-            then 1
-            else aux pcTail
-        IRActor pcId _ _ (_, _) ->
-          -- If the id is associated with a actor a value is only returned if
-          -- the identified actor has one output, otherwise the function
-          -- returns an error.
-          -- NOTE: This might be fine since if an actor has multiple outputs it
-          -- would have been represented by binder with an optional int. Will
-          -- require confirmation by exploring complex net lists.
-          if pcId == id
-            then
-              let outputRates = case (lookup pcId (pcRates context)) of
-                    Just (_, rates) -> rates
-                    Nothing -> error ("getSourceRate: No rates found for actor " ++ pcId)
-               in case outputRates of
-                    [] -> error ("getSourceRate: Empty output rates for actor " ++ pcId)
-                    [i] -> i
-                    _ -> error ("getSourceRate: More than one output rate for actor " ++ pcId)
-            else aux pcTail
+    updateConstructor :: (String, IRConstructor) -> (String, IRConstructor)
+    updateConstructor (currentPcId, currentConstructor) =
+      if pcId == currentPcId
+        then case currentConstructor of
+          IRDelay _ tokens (_, outputSignal) ->
+            let newConstructor = IRDelay currentPcId tokens (signalId, outputSignal)
+             in (currentPcId, newConstructor)
+          IRActor _ actorType functionId (inputSignals, outputSignals) ->
+            let newConstructor = IRActor currentPcId actorType functionId (signalId : inputSignals, outputSignals)
+             in (currentPcId, newConstructor)
+        else (currentPcId, currentConstructor)
+
+-- | Helper function for `createSignals` which returns the id and rate for the
+-- source of a signal based on an argument. If the argument is associated with
+-- a `Binder` which directly represents a process constructor the returned id is
+-- said pcId and the rate is 1. However, if the argument is associated with a
+-- `Binder` which indirectly represents a process constructor the the returned
+-- id is the associated bindingId and the rate is the associated index. Will
+-- temporarily use the binder as the signal source and will be updated later in
+-- the translation when all binders have been identified.
+getSourceFromArgument :: TranslationContext -> String -> (String, Int)
+getSourceFromArgument context id =
+  if elem id (systemInputs context)
+    then (id, 1)
+    else
+      let maybeBinder = (lookup id (binders context))
+       in case maybeBinder of
+            -- If the binder is just an id then it must be connected to a
+            -- process constructor with only 1 output?
+            Just (PcId pcId) -> (pcId, 1)
+            Just (Binding bindingId index) -> (bindingId, index)
+            Nothing -> error ("getSourceFromArgument - unable to identify id as a system input or binder: " ++ id)
 
 -- | Creates actors and delays by pattern matching based on the number of
--- inputs to the top function, represented by `Lam`, and inputs to the process
--- constructor, represented by `App`. If it cannot match an actor or delay then
--- it creates a function.
+-- inputs to the top level function, represented by `Lam`, and inputs to the
+-- process constructor, represented by `App`. If it cannot match an actor or
+-- delay then it creates a function.
 translateCoreExpr :: TranslationContext -> CoreBndr -> CoreExpr -> TranslationContext
 translateCoreExpr context binder expr = case expr of
-  Lam _ (Lam _ (Lam _ (App (App (App (Var (i)) _) _) _))) ->
+  Lam _ (App (App (App (Var (i)) _) _) _) ->
     let name = showPpr (flags context) i
      in case name of
           "delaySDF" -> createDelaySDF context binder expr
           _ -> error ("translateCoreExpr: expecting delaySDF got " ++ name)
-  Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _))) ->
+  Lam _ (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) ->
     let name = showPpr (flags context) i
      in case name of
           "actor11SDF" -> createActorSDF context Actor11 binder expr
           _ -> error ("translateCoreExpr: expecting actor11SDF got " ++ name)
-  Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _))) ->
+  Lam _ (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) ->
     let name = showPpr (flags context) i
      in case name of
           "actor12SDF" -> createActorSDF context Actor12 binder expr
           _ -> error ("translateCoreExpr: expecting actor12SDF got " ++ name)
-  Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _)))) ->
+  Lam _ (Lam _ (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _)) ->
     let name = showPpr (flags context) i
      in case name of
           "actor21SDF" -> createActorSDF context Actor21 binder expr
           _ -> error ("translateCoreExpr: expecting actor21SDF got " ++ name)
-  Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _)))) ->
+  Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _)) ->
     let name = showPpr (flags context) i
      in case name of
           "actor22SDF" -> createActorSDF context Actor22 binder expr
@@ -350,7 +338,8 @@ createActorSDF context actorType binder expr =
         Just functionName ->
           let (inRates, outRates) = splitAt (getActorSplit actorType) lits
               actorId = showPpr (flags context) binder
-              newActor = IRActor actorId actorType functionName ([], [])
+              baseOutputs = replicate (length outRates) ""
+              newActor = IRActor actorId actorType functionName ([], baseOutputs)
               newActorsList = (actorId, (inRates, outRates)) : (pcRates context)
            in context {pcRates = newActorsList, constructors = (actorId, newActor) : (constructors context)}
 
@@ -380,6 +369,8 @@ createFunction context binder expr =
       newFunction = IRFunction functionId (Just expr)
    in context {functions = (functionId, newFunction) : (functions context)}
 
+-- | Helper function for `createActorSDF` which returns name of the function
+-- used by the process constructor.
 getFunctionName :: TranslationContext -> CoreExpr -> Maybe String
 getFunctionName context expr = case expr of
   App e a ->

--- a/src/CoreIRToForSyDeIR.hs
+++ b/src/CoreIRToForSyDeIR.hs
@@ -1,4 +1,4 @@
-module CoreToForSyDeIR where
+module CoreIRToForSyDeIR where
 
 import CoreIR
 import Data.List (elemIndex)

--- a/src/CoreIRToForSyDeIR.hs
+++ b/src/CoreIRToForSyDeIR.hs
@@ -96,18 +96,33 @@ translateSystem initialContext expr = case expr of
 -- of the `TranslationContext` by updating constructors and signals.
 translateSystemOutputs :: TranslationContext -> CoreExpr -> TranslationContext
 translateSystemOutputs initialContext expr = case expr of
-  Var i ->
-    let outputId = showPpr (flags initialContext) i
-        (sourceId, sourceRate) = getSourceFromArgument initialContext outputId
-        newSignal = IRSignal outputId (sourceId, sourceRate) (outputId, 1)
+  Var out ->
+    let context1 = updateSystemOutput initialContext out
+        context2 = context1 {systemInputs = reverse (systemInputs context1)}
+        context3 = updateConstructorsAndSignals context2
+     in context3
+  App (App (App (App (Var _) (Type _)) (Type _)) (Var out1)) (Var out2) ->
+    let context1 = foldl updateSystemOutput initialContext [out1, out2]
         context2 =
-          initialContext
-            { systemOutputs = outputId : (systemOutputs initialContext),
-              signals = (outputId, newSignal) : (signals initialContext)
+          context1
+            { systemInputs = reverse (systemInputs context1),
+              systemOutputs = reverse (systemOutputs context1)
             }
         context3 = updateConstructorsAndSignals context2
      in context3
   _ -> error ("translateSystemOutputs: unsupported expression\n" ++ prettyCoreExpr (flags initialContext) expr)
+
+updateSystemOutput :: TranslationContext -> Id -> TranslationContext
+updateSystemOutput initialContext output =
+  let outputId = showPpr (flags initialContext) output
+      (sourceId, sourceRate) = getSourceFromArgument initialContext outputId
+      newSignal = IRSignal outputId (sourceId, sourceRate) (outputId, 1)
+      context1 =
+        initialContext
+          { systemOutputs = outputId : (systemOutputs initialContext),
+            signals = (outputId, newSignal) : (signals initialContext)
+          }
+   in context1
 
 -- | Updates all the signals within `TranslationContext` which are temporarily
 -- using a binder as the signal source. Replaces them with their associated

--- a/src/CoreToForSyDeIR.hs
+++ b/src/CoreToForSyDeIR.hs
@@ -108,6 +108,7 @@ translateInputs context expr = case expr of
         (pcId, newNewContext) = translateBodyExpr newContext [] e
         newNewNewContext = newNewContext {bindings = (binderId, pcId) : (bindings newNewContext)}
      in updateSignals newNewNewContext
+  Tick _ e -> translateInputs context e
   _ -> error ("translateInputs: unsupported expression\n" ++ prettyCoreExpr (flags context) expr)
 
 -- | Updates all the signals within `TranslationContext` which are temporarily
@@ -164,6 +165,7 @@ translateOutputs context expr = case expr of
         binderId = showPpr (flags newContext) b
         (pcId, newNewContext) = translateBodyExpr newContext [] e
      in newNewContext {bindings = (binderId, pcId) : (bindings newNewContext)}
+  Tick _ e -> translateOutputs context e
   _ -> error ("translateOutputs: unsupported expression\n" ++ prettyCoreExpr (flags context) expr)
 
 -- | Helper function for `translateOutputs` which identifies variable chosen by
@@ -196,6 +198,11 @@ translateBodyExpr context arguments expr = case expr of
   App e a ->
     let (newArguments, newContext) = translateArgument context arguments a
      in translateBodyExpr newContext newArguments e
+  -- Case (Var i) _ _ alts ->
+  --   let binder = showPpr (flags context) i
+  --       index = getIndexFromAlts context alts
+  --    in ((binder, index) : arguments, context)
+  Tick _ e -> translateBodyExpr context arguments e
   _ -> error ("translateBodyExpr: unsupported expression\n" ++ prettyCoreExpr (flags context) expr)
 
 -- Returns a list of arguments
@@ -210,6 +217,7 @@ translateArgument context arguments expr = case expr of
     let binder = showPpr (flags context) i
         index = getIndexFromAlts context alts
      in ((binder, index) : arguments, context)
+  Tick _ e -> translateArgument context arguments e
   _ -> error ("translateArgument: unsupported expression\n" ++ prettyCoreExpr (flags context) expr)
 
 getIndexFromAlts :: TranslationContext -> [Alt CoreBndr] -> (Maybe Int)

--- a/src/LSP.hs
+++ b/src/LSP.hs
@@ -14,8 +14,7 @@ import qualified Control.Exception as E
 import Control.Monad (forever, void)
 import Control.Monad.IO.Class
 import Control.Monad.IO.Unlift
-import CoreIR
-import CoreToForSyDeIR
+import CoreIRToForSyDeIR
 import Data.Aeson ((.=))
 import qualified Data.Aeson as A
 import Data.Aeson.KeyMap ((!?))
@@ -31,6 +30,7 @@ import Options.Applicative
 import Prettyprinter
 import SKGraphSchema
 import System.IO
+import Utilities
 
 diagramAcceptMethod :: SMethod (Method_CustomMethod "diagram/accept")
 diagramAcceptMethod = (SMethod_CustomMethod (Proxy @"diagram/accept"))

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -2,7 +2,7 @@ module Main where
 
 import ArgumentsMain
 import CoreIR (prettyCoreProgram)
-import CoreToForSyDeIR
+import CoreIRToForSyDeIR (translateCoreProgram)
 import ForSyDeIR (prettyIRJSON, prettyIRSystem)
 import Options.Applicative
 import Utilities (compileToCore)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,10 +1,11 @@
 module Main where
 
 import ArgumentsMain
-import CoreIR (compileToCore, prettyCoreProgram)
+import CoreIR (prettyCoreProgram)
 import CoreToForSyDeIR
 import ForSyDeIR (prettyIRJSON, prettyIRSystem)
 import Options.Applicative
+import Utilities (compileToCore)
 
 {-
 
@@ -74,7 +75,7 @@ run (Arguments (InputFile input_file) output_file OutputForSyDeIRJSON) = do
   let ir = translateCoreProgram dflags core
   let ir_json = prettyIRJSON ir
   write_output output_file OutputForSyDeIRJSON ir_json
-run (Arguments (InputFile _) _ OutputProceduralIR) =
+run (Arguments (InputFile _) _ OutputProceduralIR) = do
   putStrLn "To Procedural IR"
 -- What we have so far, take input file and write out core
 run (Arguments (InputFile input_file) output_file OutputCore) = do

--- a/src/Utilities.hs
+++ b/src/Utilities.hs
@@ -1,0 +1,85 @@
+module Utilities (noInlineTypecheck, compileToCore) where
+
+import Data.Data (Data, gmapT)
+import Data.Generics (extT)
+import GHC
+import GHC.Driver.Main
+import GHC.Paths (libdir)
+import GHC.Plugins
+import GHC.Tc.Types
+import System.FilePath (takeBaseName)
+
+-- | Custom `compileToCore` function which compiles a haskell module at a
+-- specified file path into GHC Core. Returns a `CoreProgram` and the internally
+-- defined and used `DynFlags`. This flags are used for safe pretty printing.
+compileToCore :: FilePath -> IO (CoreProgram, DynFlags)
+compileToCore filePath = runGhc (Just libdir) $ do
+  dflags <- getSessionDynFlags
+  let newDflags =
+        dflags
+          { ghcLink = NoLink,
+            ghcMode = CompManager,
+            backend = interpreterBackend,
+            verbosity = 0,
+            debugLevel = 1
+          }
+  _ <- setSessionDynFlags newDflags
+  target <- guessTarget filePath Nothing Nothing
+  setTargets [target]
+  _ <- load LoadAllTargets
+  modSummary <- getModSummary $ mkModuleName (takeBaseName filePath)
+  env <- getSession
+  parsedModule <- liftIO $ hscParse env modSummary
+  (tcg, _) <- liftIO $ hscTypecheckRename env modSummary parsedModule
+  let noInlineTcg = noInlineTypecheck tcg
+  guts <- liftIO $ hscDesugar env modSummary noInlineTcg
+  return $ (mg_binds guts, newDflags)
+
+-- | Updates all bindings within the function called `system` and adds NOINLINE
+-- pragmas. Prevents the pre optimisier run during desurgaring from inlining
+-- bindings relating to variables and functions within the compiled net list.
+--
+-- Solution is inspired by discussions from the GHC API issue:
+-- https://gitlab.haskell.org/ghc/ghc/-/issues/24386
+noInlineTypecheck :: TcGblEnv -> TcGblEnv
+noInlineTypecheck tcg = tcg {tcg_binds = applySystemBinds (tcg_binds tcg)}
+  where
+    applySystemBinds :: (Data a) => a -> a
+    applySystemBinds = gmapT (applySystemBinds `extT` checkFunBind)
+
+    checkFunBind :: HsBind GhcTc -> HsBind GhcTc
+    checkFunBind bind =
+      case bind of
+        FunBind {fun_id = var, fun_matches = matches} ->
+          let funName = occNameString (occName (unLoc var))
+           in case funName of
+                "system" -> bind {fun_id = var, fun_matches = applyLocalBinds matches}
+                _ -> bind
+        _ -> applySystemBinds bind
+
+    applyLocalBinds :: (Data a) => a -> a
+    applyLocalBinds = gmapT (applyLocalBinds `extT` noInlineBinds)
+
+    noInlineId :: Id -> Id
+    noInlineId var = var `setInlinePragma` neverInlinePragma
+
+    noInlineBinds :: HsBind GhcTc -> HsBind GhcTc
+    noInlineBinds bind = case bind of
+      VarBind {var_id = var, var_rhs = rhs} -> bind {var_id = noInlineId var, var_rhs = applyLocalBinds rhs}
+      FunBind {fun_id = var, fun_matches = matches} -> bind {fun_id = noInlineId <$> var, fun_matches = applyLocalBinds matches}
+      PatBind {pat_lhs = lhs, pat_rhs = rhs} -> bind {pat_lhs = noInlinePat <$> lhs, pat_rhs = applyLocalBinds rhs}
+      XHsBindsLR absBinds -> XHsBindsLR (noInlineAbsBinds absBinds)
+      _ -> bind
+
+    noInlinePat :: Pat GhcTc -> Pat GhcTc
+    noInlinePat pattern = case pattern of
+      VarPat ext var -> VarPat ext (noInlineId <$> var)
+      _ -> gmapT (id `extT` noInlinePat) pattern
+
+    noInlineAbsBinds :: AbsBinds -> AbsBinds
+    noInlineAbsBinds absBinds@AbsBinds {abs_binds = binds, abs_exports = exports} =
+      absBinds {abs_binds = binds, abs_exports = map noInlineABE exports}
+      where
+        noInlineABE :: ABExport -> ABExport
+        noInlineABE abe@ABE {abe_poly = poly, abe_mono = mono} =
+          abe {abe_poly = noInlineId poly, abe_mono = noInlineId mono}

--- a/src/Utilities.hs
+++ b/src/Utilities.hs
@@ -36,7 +36,7 @@ compileToCore filePath = runGhc (Just libdir) $ do
   return $ (mg_binds guts, newDflags)
 
 -- | Updates all bindings within the function called `system` and adds NOINLINE
--- pragmas. Prevents the pre optimisier run during desurgaring from inlining
+-- pragmas. Prevents the pre optimisier run during desugaring from inlining
 -- bindings relating to variables and functions within the compiled net list.
 --
 -- Solution is inspired by discussions from the GHC API issue:

--- a/src/Utilities.hs
+++ b/src/Utilities.hs
@@ -21,7 +21,7 @@ compileToCore filePath = runGhc (Just libdir) $ do
             ghcMode = CompManager,
             backend = interpreterBackend,
             verbosity = 0,
-            debugLevel = 1
+            debugLevel = 0
           }
   _ <- setSessionDynFlags newDflags
   target <- guessTarget filePath Nothing Nothing


### PR DESCRIPTION
- Made GHC typechecked module to not inline ids within the "system" function. Solution is based on discussions from: https://gitlab.haskell.org/ghc/ghc/-/issues/24386.
- Updated translation from Core IR to ForSyDe IR to take advantage of the new no inlined Core IR system net list. I think the new translation solution is much simpler to scale for more complex net lists and easier to understand.
- Added a much more robust solution for updating the inputs and outputs of constructors, no longer using a hacky solution.
- Updated comments for the new translation solution.
- Updated SDF examples to have types, it made the Core pattern matching much simpler.

Note currently SDF examples 3 is supported, as the goal was to update our solution be based on no inlined Core