### PR TITLE
Add more actor types in Core to ForSyDeIR

### DIFF
--- a/src/CoreIRToForSyDeIR.hs
+++ b/src/CoreIRToForSyDeIR.hs
@@ -221,7 +221,26 @@ translateSystemExpr initialContext expr = case expr of
     let pcId = showPpr (flags initialContext) i
         a1Id = showPpr (flags initialContext) a1
         a2Id = showPpr (flags initialContext) a2
-        arguments = [(a2Id), (a1Id)]
+        arguments = [(a1Id), (a2Id)]
+        context1 = createSignals initialContext pcId arguments
+     in (PcId pcId, context1)
+  -- Application of process constructors with 3 input
+  App (App (App (Var i) (Var a1)) (Var a2)) (Var a3) ->
+    let pcId = showPpr (flags initialContext) i
+        a1Id = showPpr (flags initialContext) a1
+        a2Id = showPpr (flags initialContext) a2
+        a3Id = showPpr (flags initialContext) a3
+        arguments = [(a1Id), (a2Id), (a3Id)]
+        context1 = createSignals initialContext pcId arguments
+     in (PcId pcId, context1)
+  -- Application of process constructors with 4 input
+  App (App (App (App (Var i) (Var a1)) (Var a2)) (Var a3)) (Var a4) ->
+    let pcId = showPpr (flags initialContext) i
+        a1Id = showPpr (flags initialContext) a1
+        a2Id = showPpr (flags initialContext) a2
+        a3Id = showPpr (flags initialContext) a3
+        a4Id = showPpr (flags initialContext) a4
+        arguments = [(a1Id), (a2Id), (a3Id), (a4Id)]
         context1 = createSignals initialContext pcId arguments
      in (PcId pcId, context1)
   Case (Var i) _ _ alts ->
@@ -332,6 +351,16 @@ translateCoreExpr context binder expr = case expr of
      in case name of
           "actor12SDF" -> createActorSDF context Actor12 binder expr
           _ -> error ("translateCoreExpr: expecting actor12SDF got " ++ name)
+  Lam _ (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) ->
+    let name = showPpr (flags context) i
+     in case name of
+          "actor13SDF" -> createActorSDF context Actor13 binder expr
+          _ -> error ("translateCoreExpr: expecting actor13SDF got " ++ name)
+  Lam _ (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) ->
+    let name = showPpr (flags context) i
+     in case name of
+          "actor14SDF" -> createActorSDF context Actor14 binder expr
+          _ -> error ("translateCoreExpr: expecting actor14SDF got " ++ name)
   Lam _ (Lam _ (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _)) ->
     let name = showPpr (flags context) i
      in case name of
@@ -342,6 +371,56 @@ translateCoreExpr context binder expr = case expr of
      in case name of
           "actor22SDF" -> createActorSDF context Actor22 binder expr
           _ -> error ("translateCoreExpr: expecting actor22SDF got " ++ name)
+  Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) _)) ->
+    let name = showPpr (flags context) i
+     in case name of
+          "actor23SDF" -> createActorSDF context Actor23 binder expr
+          _ -> error ("translateCoreExpr: expecting actor23SDF got " ++ name)
+  Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) _) _)) ->
+    let name = showPpr (flags context) i
+     in case name of
+          "actor24SDF" -> createActorSDF context Actor24 binder expr
+          _ -> error ("translateCoreExpr: expecting actor24SDF got " ++ name)
+  Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) _))) ->
+    let name = showPpr (flags context) i
+     in case name of
+          "actor31SDF" -> createActorSDF context Actor31 binder expr
+          _ -> error ("translateCoreExpr: expecting actor31SDF got " ++ name)
+  Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) _) _))) ->
+    let name = showPpr (flags context) i
+     in case name of
+          "actor32SDF" -> createActorSDF context Actor32 binder expr
+          _ -> error ("translateCoreExpr: expecting actor32SDF got " ++ name)
+  Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) _) _) _))) ->
+    let name = showPpr (flags context) i
+     in case name of
+          "actor33SDF" -> createActorSDF context Actor33 binder expr
+          _ -> error ("translateCoreExpr: expecting actor33SDF got " ++ name)
+  Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) _) _) _) _))) ->
+    let name = showPpr (flags context) i
+     in case name of
+          "actor34SDF" -> createActorSDF context Actor34 binder expr
+          _ -> error ("translateCoreExpr: expecting actor34SDF got " ++ name)
+  Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) _) _) _)))) ->
+    let name = showPpr (flags context) i
+     in case name of
+          "actor41SDF" -> createActorSDF context Actor41 binder expr
+          _ -> error ("translateCoreExpr: expecting actor41SDF got " ++ name)
+  Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) _) _) _) _)))) ->
+    let name = showPpr (flags context) i
+     in case name of
+          "actor42SDF" -> createActorSDF context Actor42 binder expr
+          _ -> error ("translateCoreExpr: expecting actor42SDF got " ++ name)
+  Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) _) _) _) _) _)))) ->
+    let name = showPpr (flags context) i
+     in case name of
+          "actor43SDF" -> createActorSDF context Actor43 binder expr
+          _ -> error ("translateCoreExpr: expecting actor43SDF got " ++ name)
+  Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) _) _) _) _) _) _)))) ->
+    let name = showPpr (flags context) i
+     in case name of
+          "actor44SDF" -> createActorSDF context Actor44 binder expr
+          _ -> error ("translateCoreExpr: expecting actor44SDF got " ++ name)
   _ -> createFunction context binder expr
 
 createDelaySDF :: TranslationContext -> CoreBndr -> CoreExpr -> TranslationContext
@@ -382,8 +461,20 @@ getActorSplit :: ActorType -> Int
 getActorSplit actorType = case actorType of
   Actor11 -> 1
   Actor12 -> 1
+  Actor13 -> 1
+  Actor14 -> 1
   Actor21 -> 2
   Actor22 -> 2
+  Actor23 -> 2
+  Actor24 -> 2
+  Actor31 -> 3
+  Actor32 -> 3
+  Actor33 -> 3
+  Actor34 -> 3
+  Actor41 -> 4
+  Actor42 -> 4
+  Actor43 -> 4
+  Actor44 -> 4
   _ -> error "getActorSplit: unsupported actor type"
 
 createFunction :: TranslationContext -> CoreBndr -> CoreExpr -> TranslationContext

--- a/src/CoreIRToForSyDeIR.hs
+++ b/src/CoreIRToForSyDeIR.hs
@@ -69,7 +69,7 @@ translateCoreBind context (NonRec b e) = case (showPpr (flags context) b) of
   _ -> translateCoreExpr context b e
 -- NOTE: Currently no SDF examples have a `Rec` in the top level of their Core
 -- output, thus unsure what the expected outcome should be.
-translateCoreBind _ (Rec _) = error "translateCoreBind: `Rec` used in top level of Core output"
+translateCoreBind _ (Rec _) = error "translateCoreBind - `Rec` used in top level of Core output"
 
 -- | Translates the `CoreExpr` which is associated with the system net list.
 -- Identifies system inputs, builds the net list through a `TranslationContext`,
@@ -115,7 +115,7 @@ translateSystemOutputs initialContext expr = case expr of
             }
         context3 = updateConstructorsAndSignals context2
      in context3
-  _ -> error ("translateSystemOutputs: unsupported expression\n" ++ prettyCoreExpr (flags initialContext) expr)
+  _ -> error ("translateSystemOutputs - Unsupported expression\n" ++ prettyCoreExpr (flags initialContext) expr)
 
 updateSystemOutput :: TranslationContext -> Id -> TranslationContext
 updateSystemOutput initialContext output =
@@ -158,7 +158,7 @@ updateConstructorsAndSignals initialContext =
                       newSignal = IRSignal signalId (pcId, outputRates !! sourceRate) (targetId, targetRate)
                       context1 = updateConstructorsOutputs currentContext signalId pcId sourceRate
                    in aux context1 signalsTail ((signalId, newSignal) : acc)
-                _ -> error ("updateConstructorsAndSignals - binder is not associated with any process constructors")
+                _ -> error ("updateConstructorsAndSignals - Binder is not associated with any process constructors")
               Nothing ->
                 -- Signal source was already a process constructor meaning it
                 -- only had 1 output, thus passing index zero
@@ -180,7 +180,7 @@ updateConstructorsOutputs initialContext signalId pcId index =
         then case currentConstructor of
           IRDelay _ tokens (inputSignal, _) ->
             if index /= 0
-              then error ("updateConstructorsOutputs - pcId matches a delay but has a non-zero index")
+              then error ("updateConstructorsOutputs - Process constructor id matches a delay but has a non-zero index")
               else
                 let newConstructor = IRDelay currentPcId tokens (inputSignal, signalId)
                  in (currentPcId, newConstructor)
@@ -213,26 +213,29 @@ translateSystemExpr initialContext expr = case expr of
   App (Var i) (Var a) ->
     let pcId = showPpr (flags initialContext) i
         aId = showPpr (flags initialContext) a
-        arguments = [(aId)]
+        arguments = [aId]
         context1 = createSignalsFromArguments initialContext pcId arguments
-     in (PcId pcId, context1)
+        binder = PcId pcId
+     in (binder, context1)
   -- Application of process constructors with 2 input
   App (App (Var i) (Var a1)) (Var a2) ->
     let pcId = showPpr (flags initialContext) i
         a1Id = showPpr (flags initialContext) a1
         a2Id = showPpr (flags initialContext) a2
-        arguments = [(a1Id), (a2Id)]
+        arguments = [a1Id, a2Id]
         context1 = createSignalsFromArguments initialContext pcId arguments
-     in (PcId pcId, context1)
+        binder = PcId pcId
+     in (binder, context1)
   -- Application of process constructors with 3 input
   App (App (App (Var i) (Var a1)) (Var a2)) (Var a3) ->
     let pcId = showPpr (flags initialContext) i
         a1Id = showPpr (flags initialContext) a1
         a2Id = showPpr (flags initialContext) a2
         a3Id = showPpr (flags initialContext) a3
-        arguments = [(a1Id), (a2Id), (a3Id)]
+        arguments = [a1Id, a2Id, a3Id]
         context1 = createSignalsFromArguments initialContext pcId arguments
-     in (PcId pcId, context1)
+        binder = PcId pcId
+     in (binder, context1)
   -- Application of process constructors with 4 input
   App (App (App (App (Var i) (Var a1)) (Var a2)) (Var a3)) (Var a4) ->
     let pcId = showPpr (flags initialContext) i
@@ -240,27 +243,29 @@ translateSystemExpr initialContext expr = case expr of
         a2Id = showPpr (flags initialContext) a2
         a3Id = showPpr (flags initialContext) a3
         a4Id = showPpr (flags initialContext) a4
-        arguments = [(a1Id), (a2Id), (a3Id), (a4Id)]
+        arguments = [a1Id, a2Id, a3Id, a4Id]
         context1 = createSignalsFromArguments initialContext pcId arguments
-     in (PcId pcId, context1)
+        binder = PcId pcId
+     in (binder, context1)
   Case (Var i) _ _ alts ->
     let bindingId = showPpr (flags initialContext) i
         index = getIndexFromAlts initialContext alts
-     in ((Binding bindingId index), initialContext)
-  _ -> error ("translateSystemExpr - unsupported CoreExpr:\n" ++ prettyCoreExpr (flags initialContext) expr)
+        binder = Binding bindingId index
+     in (binder, initialContext)
+  _ -> error ("translateSystemExpr - Unsupported CoreExpr:\n" ++ prettyCoreExpr (flags initialContext) expr)
 
 -- | Helper function which identifies the id chosen by an `AltCon` for a `Case`.
 -- Returns the index of the identified id from a list of ids. These ids
 -- represent the outputs of a process constructor.
 getIndexFromAlts :: TranslationContext -> [Alt CoreBndr] -> Int
 getIndexFromAlts context alts = case alts of
-  [] -> error ("getIndexFromAlts - empty AltCon list")
+  [] -> error ("getIndexFromAlts - Empty AltCon list")
   (Alt _ ids (Var (i))) : [] ->
     let maybeIndex = elemIndex i ids
      in case maybeIndex of
           Just index -> index
-          Nothing -> error ("getIndexFromAlts - unable to find: " ++ showPpr (flags context) i)
-  _ -> error ("getIndexFromAlts - more than one AltCon:\n" ++ prettyCoreAltList (flags context) alts)
+          Nothing -> error ("getIndexFromAlts - Unable to find: " ++ showPpr (flags context) i)
+  _ -> error ("getIndexFromAlts - More than one AltCon:\n" ++ prettyCoreAltList (flags context) alts)
 
 -- | Creates signals based on the arguments of a process constructor. All
 -- signals created with this function have the process constructor as the
@@ -344,91 +349,40 @@ getSourceFromArgument context argument =
 -- translation to support additional process constructors.
 translateCoreExpr :: TranslationContext -> CoreBndr -> CoreExpr -> TranslationContext
 translateCoreExpr context binder expr = case expr of
-  Lam _ (App (App (App (Var (i)) _) _) _) ->
-    let name = showPpr (flags context) i
-     in case name of
-          "delaySDF" -> createDelaySDF context binder expr
-          _ -> error ("translateCoreExpr: expecting delaySDF got " ++ name)
-  Lam _ (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) ->
-    let name = showPpr (flags context) i
-     in case name of
-          "actor11SDF" -> createActorSDF context Actor11 binder expr
-          _ -> error ("translateCoreExpr: expecting actor11SDF got " ++ name)
-  Lam _ (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) ->
-    let name = showPpr (flags context) i
-     in case name of
-          "actor12SDF" -> createActorSDF context Actor12 binder expr
-          _ -> error ("translateCoreExpr: expecting actor12SDF got " ++ name)
-  Lam _ (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) ->
-    let name = showPpr (flags context) i
-     in case name of
-          "actor13SDF" -> createActorSDF context Actor13 binder expr
-          _ -> error ("translateCoreExpr: expecting actor13SDF got " ++ name)
-  Lam _ (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) ->
-    let name = showPpr (flags context) i
-     in case name of
-          "actor14SDF" -> createActorSDF context Actor14 binder expr
-          _ -> error ("translateCoreExpr: expecting actor14SDF got " ++ name)
-  Lam _ (Lam _ (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _)) ->
-    let name = showPpr (flags context) i
-     in case name of
-          "actor21SDF" -> createActorSDF context Actor21 binder expr
-          _ -> error ("translateCoreExpr: expecting actor21SDF got " ++ name)
-  Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _)) ->
-    let name = showPpr (flags context) i
-     in case name of
-          "actor22SDF" -> createActorSDF context Actor22 binder expr
-          _ -> error ("translateCoreExpr: expecting actor22SDF got " ++ name)
-  Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) _)) ->
-    let name = showPpr (flags context) i
-     in case name of
-          "actor23SDF" -> createActorSDF context Actor23 binder expr
-          _ -> error ("translateCoreExpr: expecting actor23SDF got " ++ name)
-  Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) _) _)) ->
-    let name = showPpr (flags context) i
-     in case name of
-          "actor24SDF" -> createActorSDF context Actor24 binder expr
-          _ -> error ("translateCoreExpr: expecting actor24SDF got " ++ name)
-  Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) _))) ->
-    let name = showPpr (flags context) i
-     in case name of
-          "actor31SDF" -> createActorSDF context Actor31 binder expr
-          _ -> error ("translateCoreExpr: expecting actor31SDF got " ++ name)
-  Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) _) _))) ->
-    let name = showPpr (flags context) i
-     in case name of
-          "actor32SDF" -> createActorSDF context Actor32 binder expr
-          _ -> error ("translateCoreExpr: expecting actor32SDF got " ++ name)
-  Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) _) _) _))) ->
-    let name = showPpr (flags context) i
-     in case name of
-          "actor33SDF" -> createActorSDF context Actor33 binder expr
-          _ -> error ("translateCoreExpr: expecting actor33SDF got " ++ name)
-  Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) _) _) _) _))) ->
-    let name = showPpr (flags context) i
-     in case name of
-          "actor34SDF" -> createActorSDF context Actor34 binder expr
-          _ -> error ("translateCoreExpr: expecting actor34SDF got " ++ name)
-  Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) _) _) _)))) ->
-    let name = showPpr (flags context) i
-     in case name of
-          "actor41SDF" -> createActorSDF context Actor41 binder expr
-          _ -> error ("translateCoreExpr: expecting actor41SDF got " ++ name)
-  Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) _) _) _) _)))) ->
-    let name = showPpr (flags context) i
-     in case name of
-          "actor42SDF" -> createActorSDF context Actor42 binder expr
-          _ -> error ("translateCoreExpr: expecting actor42SDF got " ++ name)
-  Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) _) _) _) _) _)))) ->
-    let name = showPpr (flags context) i
-     in case name of
-          "actor43SDF" -> createActorSDF context Actor43 binder expr
-          _ -> error ("translateCoreExpr: expecting actor43SDF got " ++ name)
-  Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (App (App (App (Var (i)) _) _) _) _) _) _) _) _) _) _) _) _) _) _) _)))) ->
-    let name = showPpr (flags context) i
-     in case name of
-          "actor44SDF" -> createActorSDF context Actor44 binder expr
-          _ -> error ("translateCoreExpr: expecting actor44SDF got " ++ name)
+  Lam _ (App (App (App (Var i) _) _) _)
+    | showPpr (flags context) i == "delaySDF" -> createDelaySDF context binder expr
+  Lam _ (App (App (App (App (App (App (Var i) _) _) _) _) _) _)
+    | showPpr (flags context) i == "actor11SDF" -> createActorSDF context Actor11 binder expr
+  Lam _ (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _)
+    | showPpr (flags context) i == "actor12SDF" -> createActorSDF context Actor12 binder expr
+  Lam _ (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _)
+    | showPpr (flags context) i == "actor13SDF" -> createActorSDF context Actor13 binder expr
+  Lam _ (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _)
+    | showPpr (flags context) i == "actor14SDF" -> createActorSDF context Actor14 binder expr
+  Lam _ (Lam _ (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _))
+    | showPpr (flags context) i == "actor21SDF" -> createActorSDF context Actor21 binder expr
+  Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _))
+    | showPpr (flags context) i == "actor22SDF" -> createActorSDF context Actor22 binder expr
+  Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _))
+    | showPpr (flags context) i == "actor23SDF" -> createActorSDF context Actor23 binder expr
+  Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _))
+    | showPpr (flags context) i == "actor24SDF" -> createActorSDF context Actor24 binder expr
+  Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _)))
+    | showPpr (flags context) i == "actor31SDF" -> createActorSDF context Actor31 binder expr
+  Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _)))
+    | showPpr (flags context) i == "actor32SDF" -> createActorSDF context Actor32 binder expr
+  Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _) _)))
+    | showPpr (flags context) i == "actor33SDF" -> createActorSDF context Actor33 binder expr
+  Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _) _) _)))
+    | showPpr (flags context) i == "actor34SDF" -> createActorSDF context Actor34 binder expr
+  Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _) _))))
+    | showPpr (flags context) i == "actor41SDF" -> createActorSDF context Actor41 binder expr
+  Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _) _) _))))
+    | showPpr (flags context) i == "actor42SDF" -> createActorSDF context Actor42 binder expr
+  Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _) _) _) _))))
+    | showPpr (flags context) i == "actor43SDF" -> createActorSDF context Actor43 binder expr
+  Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _) _) _) _) _))))
+    | showPpr (flags context) i == "actor44SDF" -> createActorSDF context Actor44 binder expr
   _ -> createFunction context binder expr
 
 createDelaySDF :: TranslationContext -> CoreBndr -> CoreExpr -> TranslationContext
@@ -444,7 +398,7 @@ createActorSDF initialContext actorType binder expr =
   let lits = getLits expr []
       maybeFunctionName = getFunctionName initialContext expr
    in case maybeFunctionName of
-        Nothing -> error "No function found for actor"
+        Nothing -> error "createActorSDF - No function found for actor"
         Just functionName ->
           let (inputRates, outputRates) = splitAt (getActorSplit actorType) lits
               actorId = showPpr (flags initialContext) binder

--- a/src/CoreIRToForSyDeIR.hs
+++ b/src/CoreIRToForSyDeIR.hs
@@ -154,11 +154,11 @@ updateConstructorsAndSignals initialContext =
                   -- the index of the output rather than a rate
                   let outputRates = case (lookup pcId (pcRates currentContext)) of
                         Just (_, rates) -> rates
-                        Nothing -> error ("updateSignals - No rates found for actor: " ++ pcId)
+                        Nothing -> error ("updateConstructorsAndSignals - No rates found for process constructor: " ++ pcId)
                       newSignal = IRSignal signalId (pcId, outputRates !! sourceRate) (targetId, targetRate)
                       context1 = updateConstructorsOutputs currentContext signalId pcId sourceRate
                    in aux context1 signalsTail ((signalId, newSignal) : acc)
-                _ -> error ("updateSignals - binder is not associated with any process constructors")
+                _ -> error ("updateConstructorsAndSignals - binder is not associated with any process constructors")
               Nothing ->
                 -- Signal source was already a process constructor meaning it
                 -- only had 1 output, thus passing index zero
@@ -214,7 +214,7 @@ translateSystemExpr initialContext expr = case expr of
     let pcId = showPpr (flags initialContext) i
         aId = showPpr (flags initialContext) a
         arguments = [(aId)]
-        context1 = createSignals initialContext pcId arguments
+        context1 = createSignalsFromArguments initialContext pcId arguments
      in (PcId pcId, context1)
   -- Application of process constructors with 2 input
   App (App (Var i) (Var a1)) (Var a2) ->
@@ -222,7 +222,7 @@ translateSystemExpr initialContext expr = case expr of
         a1Id = showPpr (flags initialContext) a1
         a2Id = showPpr (flags initialContext) a2
         arguments = [(a1Id), (a2Id)]
-        context1 = createSignals initialContext pcId arguments
+        context1 = createSignalsFromArguments initialContext pcId arguments
      in (PcId pcId, context1)
   -- Application of process constructors with 3 input
   App (App (App (Var i) (Var a1)) (Var a2)) (Var a3) ->
@@ -231,7 +231,7 @@ translateSystemExpr initialContext expr = case expr of
         a2Id = showPpr (flags initialContext) a2
         a3Id = showPpr (flags initialContext) a3
         arguments = [(a1Id), (a2Id), (a3Id)]
-        context1 = createSignals initialContext pcId arguments
+        context1 = createSignalsFromArguments initialContext pcId arguments
      in (PcId pcId, context1)
   -- Application of process constructors with 4 input
   App (App (App (App (Var i) (Var a1)) (Var a2)) (Var a3)) (Var a4) ->
@@ -241,7 +241,7 @@ translateSystemExpr initialContext expr = case expr of
         a3Id = showPpr (flags initialContext) a3
         a4Id = showPpr (flags initialContext) a4
         arguments = [(a1Id), (a2Id), (a3Id), (a4Id)]
-        context1 = createSignals initialContext pcId arguments
+        context1 = createSignalsFromArguments initialContext pcId arguments
      in (PcId pcId, context1)
   Case (Var i) _ _ alts ->
     let bindingId = showPpr (flags initialContext) i
@@ -265,15 +265,15 @@ getIndexFromAlts context alts = case alts of
 -- | Creates signals based on the arguments of a process constructor. All
 -- signals created with this function have the process constructor as the
 -- target.
-createSignals :: TranslationContext -> String -> [(String)] -> TranslationContext
-createSignals context pcId arguments =
+createSignalsFromArguments :: TranslationContext -> String -> [(String)] -> TranslationContext
+createSignalsFromArguments context pcId arguments =
   -- The input rates of the process constructor are used to determine the
   -- targetRate of created signals, the index for the input is the same as the
   -- current arguments index.
   let inputRates = case (lookup pcId (pcRates context)) of
         Just (rates, _) -> rates
-        Nothing -> error ("createSignals - No rates found for actor: " ++ pcId)
-   in aux context arguments inputRates
+        Nothing -> error ("createSignalsFromArguments - No rates found for process constructor: " ++ pcId)
+   in aux context (reverse arguments) (reverse inputRates)
   where
     aux :: TranslationContext -> [(String)] -> [Int] -> TranslationContext
     aux currentContext currentArguments rates = case (currentArguments, rates) of
@@ -282,7 +282,8 @@ createSignals context pcId arguments =
       (argumentsHead : argumentsTail, ratesHead : ratesTail) ->
         let (sourceId, sourceRate) = getSourceFromArgument currentContext argumentsHead
             newSignal = IRSignal argumentsHead (sourceId, sourceRate) (pcId, ratesHead)
-            context1 = currentContext {signals = (argumentsHead, newSignal) : (signals currentContext)}
+            newSignals = (argumentsHead, newSignal) : (signals currentContext)
+            context1 = currentContext {signals = newSignals}
             context2 = updateConstructorsInputs context1 pcId argumentsHead
          in aux context2 argumentsTail ratesTail
 
@@ -306,26 +307,33 @@ updateConstructorsInputs initialContext pcId signalId =
              in (currentPcId, newConstructor)
         else (currentPcId, currentConstructor)
 
--- | Helper function for `createSignals` which returns the id and rate for the
--- source of a signal based on an argument. If the argument is associated with
--- a `Binder` which directly represents a process constructor the returned id is
--- said pcId and the rate is 1. However, if the argument is associated with a
--- `Binder` which indirectly represents a process constructor the the returned
--- id is the associated bindingId and the rate is the associated index. Will
--- temporarily use the binder as the signal source and will be updated later in
--- the translation when all binders have been identified.
+-- | Helper function for `createSignalsFromArguments` which returns the id and
+-- rate for the source of a signal based on an argument.
+--
+-- NOTE: If argument does not directly represent a process constructor then a
+-- temporary source is returned. It will have to be updated later by
+-- `updateConstructorsAndSignals` when all binders have been identified.
 getSourceFromArgument :: TranslationContext -> String -> (String, Int)
-getSourceFromArgument context id =
-  if elem id (systemInputs context)
-    then (id, 1)
+getSourceFromArgument context argument =
+  if elem argument (systemInputs context)
+    then (argument, 1)
     else
-      let maybeBinder = (lookup id (binders context))
+      let maybeBinder = (lookup argument (binders context))
        in case maybeBinder of
-            -- If the binder is just an id then it must be connected to a
-            -- process constructor with only 1 output?
-            Just (PcId pcId) -> (pcId, 1)
+            -- Argument is associated with a binder which directly represents a
+            -- process constructor meaning said constructor only has 1 output.
+            Just (PcId pcId) ->
+              let outputRates = case (lookup pcId (pcRates context)) of
+                    Just (_, rates) -> rates
+                    Nothing -> error ("getSourceFromArgument - No rates found for process constructor: " ++ pcId)
+               in (pcId, outputRates !! 0)
+            -- Argument is associated with a binder which indirectly represents
+            -- a process constructor meaning said constructor has multiple
+            -- outputs. Will temporarily use the binder as the signal source.
+            -- This will be updated later in the translation when all binders
+            -- have been identified.
             Just (Binding bindingId index) -> (bindingId, index)
-            Nothing -> error ("getSourceFromArgument - unable to identify id as a system input or binder: " ++ id)
+            Nothing -> error ("getSourceFromArgument - Unable to identify argument as a system input or binder: " ++ argument)
 
 -- | Creates actors and delays by pattern matching based on the number of
 -- inputs to the top level function, represented by `Lam`, and inputs to the
@@ -432,18 +440,20 @@ createDelaySDF context binder expr =
    in context {constructors = (delayId, newDelay) : (constructors context), pcRates = newActorsList}
 
 createActorSDF :: TranslationContext -> ActorType -> CoreBndr -> CoreExpr -> TranslationContext
-createActorSDF context actorType binder expr =
+createActorSDF initialContext actorType binder expr =
   let lits = getLits expr []
-      maybeFunctionName = getFunctionName context expr
+      maybeFunctionName = getFunctionName initialContext expr
    in case maybeFunctionName of
         Nothing -> error "No function found for actor"
         Just functionName ->
-          let (inRates, outRates) = splitAt (getActorSplit actorType) lits
-              actorId = showPpr (flags context) binder
-              baseOutputs = replicate (length outRates) ""
+          let (inputRates, outputRates) = splitAt (getActorSplit actorType) lits
+              actorId = showPpr (flags initialContext) binder
+              baseOutputs = replicate (length outputRates) ""
               newActor = IRActor actorId actorType functionName ([], baseOutputs)
-              newActorsList = (actorId, (inRates, outRates)) : (pcRates context)
-           in context {pcRates = newActorsList, constructors = (actorId, newActor) : (constructors context)}
+              newActors = (actorId, (inputRates, outputRates)) : (pcRates initialContext)
+              newConstructors = (actorId, newActor) : (constructors initialContext)
+              context1 = initialContext {pcRates = newActors, constructors = newConstructors}
+           in context1
 
 -- | Helper function for `createDelaySDF` and `createActorSDF` which returns
 -- all integer literals within their expression as a list.
@@ -475,7 +485,6 @@ getActorSplit actorType = case actorType of
   Actor42 -> 4
   Actor43 -> 4
   Actor44 -> 4
-  _ -> error "getActorSplit: unsupported actor type"
 
 createFunction :: TranslationContext -> CoreBndr -> CoreExpr -> TranslationContext
 createFunction context binder expr =


### PR DESCRIPTION
Adding as draft as I am still debugging a couple of things.

## Changes
Adds the remaining actors to Core -> ForSyDe IR.

I do this by adding cases for them in:

- `translateCoreExpr` - Add the other actors
- `getActorSplit` - Add the other actors
- `translateSystemExpr` - Add so that it supports 3,4 inputs as well (covers all other actors). NOTE: I additionally reversed the `arguments` lists, see below:

## Tests

I am running tests on `models/examples/SDF_example_006.hs` and `models/examples/SDF_example_007.hs`. Here is a drawing of both of them:
(sry for only having drawing and no tikz)
<img width="1336" height="1124" alt="sdf_006_007" src="https://github.com/user-attachments/assets/ac212cab-0ab3-4624-9f3a-b2e8b75ad0fb" />

### `SDF_example_006.hs`

Generally this looks correct. But here is why I reversed the arguments in the `translateSystemExpr`, without doing so I received the following output:

```
IRSystem(
  {"s_in"}, {"s_out"},
  {
    IRActor("a_a", Actor14, "f_1", {"s_in"}, {"s_1", "s_2", "s_3", "s_4"}),
    IRActor("a_b", Actor21, "f_2", {"s_1", "s_2"}, {"s_5"}),
    IRActor("a_c", Actor12, "f_3", {"s_3"}, {"s_6", "s_7"}),
    IRActor("a_d", Actor21, "f_4", {"s_5", "s_6"}, {"s_8"}),
    IRActor("a_e", Actor31, "f_5", {"s_8", "s_7", "s_4"}, {"s_out"})
  },
  {
    IRSignal("s_in", ("s_in", 1), ("a_a", 2)),
    IRSignal("s_2", ("a_a", 3), ("a_b", 1)),
    IRSignal("s_1", ("a_a", 1), ("a_b", 3)),
    IRSignal("s_3", ("a_a", 2), ("a_c", 2)),
    IRSignal("s_6", ("a_c", 2), ("a_d", 2)),
    IRSignal("s_5", ("a_b", 1), ("a_d", 2)),
    IRSignal("s_4", ("a_a", 4), ("a_e", 2)),
    IRSignal("s_7", ("a_c", 1), ("a_e", 1)),
    IRSignal("s_8", ("a_d", 1), ("a_e", 4)),
    IRSignal("s_out", ("a_e", 1), ("s_out", 1))
  },
```

the issue here is that `s_1` goes from a->b with output rate 1 from a and input rate 3 on b, and `s_2` goes from a->b with output rate 3 from a and input rate 1 on b. This is clearly wrong, showing that they are going to the "wrong inputs" (despite `a_b` having arguments `{"s_1", "s_2"}`, but if I reverse the arguments I get the following graph:

```
IRSystem(
  {"s_in"}, {"s_out"},
  {
    IRActor("a_a", Actor14, "f_1", {"s_in"}, {"s_1", "s_2", "s_3", "s_4"}),
    IRActor("a_b", Actor21, "f_2", {"s_2", "s_1"}, {"s_5"}),
    IRActor("a_c", Actor12, "f_3", {"s_3"}, {"s_6", "s_7"}),
    IRActor("a_d", Actor21, "f_4", {"s_6", "s_5"}, {"s_8"}),
    IRActor("a_e", Actor31, "f_5", {"s_4", "s_7", "s_8"}, {"s_out"})
  },
  {
    IRSignal("s_in", ("s_in", 1), ("a_a", 2)),
    IRSignal("s_1", ("a_a", 1), ("a_b", 1)),
    IRSignal("s_2", ("a_a", 3), ("a_b", 3)),
    IRSignal("s_3", ("a_a", 2), ("a_c", 2)),
    IRSignal("s_5", ("a_b", 1), ("a_d", 2)),
    IRSignal("s_6", ("a_c", 2), ("a_d", 2)),
    IRSignal("s_8", ("a_d", 1), ("a_e", 2)),
    IRSignal("s_7", ("a_c", 1), ("a_e", 1)),
    IRSignal("s_4", ("a_a", 4), ("a_e", 4)),
    IRSignal("s_out", ("a_e", 1), ("s_out", 1))
  },
```
where the input order is now reversed on 
```
IRActor("a_b", Actor21, "f_2", {"s_2", "s_1"}, {"s_5"}),
```
but all of the signals are correctly routed (i.e s_1 goes from 1->1 and s_2 goes from 3->3). Is the issue actually that we are applying `(Var a1)` etc in the wrong order or something else? I also don't understand why I did not have this issue in `SDF_example_007.hs`

### `SDF_example_007.hs`

I get the following ForSyDe IR:

```
IRSystem(
  {"s_in_a", "s_in_b"}, {"s_out"},
  {
    IRActor("a_a", Actor12, "f_1", {"s_in_a"}, {"s_1", "s_2"}),
    IRActor("a_b", Actor13, "f_2", {"s_in_b"}, {"s_3", "s_4", "s_5"}),
    IRActor("a_c", Actor32, "f_3", {"s_4", "s_3", "s_2"}, {"s_6", "s_7"}),
    IRActor("a_d", Actor41, "f_4", {"s_5", "s_7", "s_6", "s_1"}, {"s_out"})
  },
  {
    IRSignal("s_in_b", ("s_in_b", 1), ("a_b", 1)),
    IRSignal("s_in_a", ("s_in_a", 1), ("a_a", 2)),
    IRSignal("s_2", ("a_a", 1), ("a_c", 2)),
    IRSignal("s_3", ("a_b", 2), ("a_c", 4)),
    IRSignal("s_4", ("a_b", 1), ("a_c", 2)),
    IRSignal("s_1", ("a_a", 2), ("a_d", 4)),
    IRSignal("s_6", ("a_c", 2), ("a_d", 2)),
    IRSignal("s_7", ("a_c", 2), ("a_d", 2)),
    IRSignal("s_5", ("a_b", 2), ("a_d", 4)),
    IRSignal("s_out", ("a_d", 1), ("s_out", 1))
  },
```
the only thing that looks wrong is 
```
    IRSignal("s_out", ("a_d", 1), ("s_out", 1))
```
where the correct output should be
```
    IRSignal("s_out", ("a_d", 2), ("s_out", 1))
```
Is it something about having an actor with multiple outputs causing other models to be correct (binder to output), and since this one is from actor to output it gets 1 as default output rate?  `SDF_example_002.hs` has correct output rate 2, but I am unsure if the other models with single output only have 1 as token output rate and as a result are "accidentally correct".