### PR TITLE
Add KArc and KSpline

### DIFF
--- a/src/SKGraphSchema.hs
+++ b/src/SKGraphSchema.hs
@@ -89,7 +89,9 @@ instance A.ToJSON KStyle where
 data KRendering
   = KEllipse [KStyle]
   | KPolyline [KStyle]
-  | KRoundedBendsPolyline [KStyle] Int
+  | KRoundedBendsPolyline [KStyle] Int -- bendRadius (Int)
+  | KArc [KStyle] Float Float -- startAngle (Float), arcAngle (Float)
+  | KSpline [KStyle]
   | KRectangle [KStyle]
   | KText T.Text [KStyle]
 
@@ -109,6 +111,20 @@ instance A.ToJSON KRendering where
               [ "klighd.lsp.rendering.id" .= T.pack "$R0"
               ]
         ]
+    KArc styles startAngle arcAngle ->
+      A.object
+        [ "type" .= T.pack "KArcImpl",
+          "children" .= (Seq.empty :: Seq.Seq A.Object),
+          "actions" .= (Seq.empty :: Seq.Seq A.Object),
+          "styles" .= styles,
+          "startAngle" .= startAngle,
+          "arcAngle" .= arcAngle,
+          "properties"
+            .= A.object
+              [ "klighd.lsp.rendering.id" .= T.pack "$R0"
+              ]
+        ]
+    KSpline styles -> simple "KSplineImpl" styles
     KRectangle styles -> simple "KRectangleImpl" styles
     KText text styles ->
       A.object


### PR DESCRIPTION
Added `KArc` and `KSpline` I just tested that they worked by replacing 
```hs
        edge =
          KEdge
            { gid = name,
              children = [KLabel {gid = sigid, label = T.pack n}],
              renderings = [KRoundedBendsPolyline [] 4],
              properties = [],
              source = sn,
              target = tn
            }
```
in LSP with the different `renderings = ` for the other types of lines. for `example/models/SDF_example_003.hs`. `KArc` did not really work that well since hardcoding all edges to have the same start angle and arc angle doesn't really work.