### PR TITLE
jank: VSCode task that runs LSP

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+    "tasks": [
+        {
+            "type": "shell",
+            "label": "Run ForSyDe LSP",
+            "command": "./run.sh ${file}",
+            "args": [],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "detail": "Run Haskell LSP and klighd client"
+        }
+    ],
+    "version": "2.0.0"
+}

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+. ~/.nix-profile/etc/profile.d/nix.sh
+nix develop --command bash -c "cabal exec forsyde-lsp-exe --" &
+sleep 2 # Add a dumb delay because nix develop is so slow
+./klighd-linux --ls_port 5007 $1


### PR DESCRIPTION
I was playing around with VSCode tasks, just want to show how you could interact with VSCode to create tasks to get the visualizer running. Will mark as "draft" and should be closed after some people have taken a look at it.

## Instructions

- In VSCode, open the `forsyde-devtools` folder.
- Make sure that `klighd-linux` is in your `forsyde-devtools` folder
- Also make sure that you have run `cabal build` and that the binary is up to date.
- Open up a ForSyDe model in your VSCode editor, then press `Ctrl+Shift+B`, this will invoke a build task that calls `run.sh` that will start the LSP server and call `klighd-linux` client with your currently open ForSyDe model file as argument, and the diagram should be displayed in your browser.
- After you closed the browser, you need to Ctrl+C the terminal window for the server or just close it.