### PR TITLE
Stdout for LSP argument parsing

### DIFF
--- a/src/ArgumentsLSP.hs
+++ b/src/ArgumentsLSP.hs
@@ -7,6 +7,10 @@ data Input
   = InputFile FilePath
   | FromClient
 
+data Output
+  = ToClient
+  | StdOut
+
 -- Host IP(V4) address
 data IP
   = Host String
@@ -26,6 +30,11 @@ data Arguments = Arguments
     input :: Input
   }
 
+inputTop :: Parser Input
+inputTop =
+  inputFile
+    <|> inputFromClient
+
 -- Handle file input. Default is to get the file from your client, but
 -- allow user to pass a filename directly to server for debugging.
 inputFile :: Parser Input
@@ -35,6 +44,14 @@ inputFile =
     ( metavar "INPUT"
         <> value FromClient
         <> help "Input filename (debug option), if unset get file from client"
+    )
+
+inputFromClient :: Parser Input
+inputFromClient =
+  flag'
+    FromClient
+    ( long "input-client"
+        <> help "Input from client (default)"
     )
 
 -- IP - String "127.0.0.1" by default, otherwise provide -a or --address and
@@ -70,4 +87,4 @@ arguments =
   Arguments
     <$> ipAddress
     <*> tcpPort
-    <*> inputFile
+    <*> inputTop

--- a/src/LSP.hs
+++ b/src/LSP.hs
@@ -17,7 +17,10 @@ import Control.Monad.IO.Unlift
 import CoreIRToForSyDeIR
 import Data.Aeson ((.=))
 import qualified Data.Aeson as A
+import Data.Aeson.Encode.Pretty as AP
 import Data.Aeson.KeyMap ((!?))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy.Char8 as BSL8
 import qualified Data.List.NonEmpty as NE
 import Data.Proxy
 import qualified Data.Sequence as Seq
@@ -244,7 +247,7 @@ runServerC =
     (L.cmap (fmap $ T.pack . show . pretty) (L.cmap show L.logStringStderr))
 
 -- | Process arguments for the LSP and run it
-main :: IO Int
+main :: IO ()
 main = run =<< execParser opts
   where
     opts =
@@ -256,23 +259,34 @@ main = run =<< execParser opts
         )
 
 -- | Start the LSP
-run :: Arguments -> IO Int
-run (Arguments (Host ip) (TCP p) f) =
-  runTCPServer (Just ip) p lsp
-  where
-    lsp s = do
-      handle <- socketToHandle s ReadWriteMode
-      runServerC handle handle $
-        ServerDefinition
-          { parseConfig = const $ const $ Right Nothing,
-            onConfigChange = const $ pure (),
-            defaultConfig = Nothing,
-            configSection = "demo",
-            doInitialize = \env _req -> pure $ Right env,
-            staticHandlers = \_caps -> (handlers f),
-            interpretHandler = \env -> Iso (runLspT env) liftIO,
-            options = defaultOptions
-          }
+run :: Arguments -> IO ()
+run (Arguments (Host ip) (TCP p) i_f) =
+  case i_f of
+    FromClient ->
+      runTCPServer (Just ip) p lsp
+      where
+        lsp s = do
+          handle <- socketToHandle s ReadWriteMode
+          -- server returns IO Int, wrapper with "pure ()" so that expression
+          -- returns IO ()
+          _ <-
+            runServerC handle handle $
+              ServerDefinition
+                { parseConfig = const $ const $ Right Nothing,
+                  onConfigChange = const $ pure (),
+                  defaultConfig = Nothing,
+                  configSection = "demo",
+                  doInitialize = \env _req -> pure $ Right env,
+                  staticHandlers = \_caps -> (handlers FromClient),
+                  interpretHandler = \env -> Iso (runLspT env) liftIO,
+                  options = defaultOptions
+                }
+          pure ()
+    InputFile f -> do
+      (core, dflags) <- withRunInIO (\_u -> compileToCore f)
+      let ir = translateCoreProgram dflags core
+      let graphMessage = requestBounds f ir
+      BSL8.putStrLn $ AP.encodePretty graphMessage
 
 -- | Listen on host and port, as well as accept and fork off connections
 runTCPServer :: Maybe HostName -> ServiceName -> (Socket -> IO a1) -> IO a2


### PR DESCRIPTION
Created argument parsing for `stdin`/`stdout` for the LSP. Marked as draft/WIP since I am currently not 100% sure on how it is supposed to be integrated with the rest of the program. 

- If I have `--stdin` where do I need to `read`, since the function itself makes the function call return `-> IO ()` or `-> IO [Char]` or something so it needs to be wrapped at a point like `main`/`run` where IO is already performed. 

- Then if `--stdout` is passed it needs to be implemented such that the TCP server is not ran at all or something.