### PR TITLE
Add shell completions for bash/fish/zsh and add executables to path

### DIFF
--- a/.completions/forsyde-devtools-exe/bash
+++ b/.completions/forsyde-devtools-exe/bash
@@ -1,0 +1,14 @@
+_forsyde-devtools-exe()
+{
+    local CMDLINE
+    local IFS=$'\n'
+    CMDLINE=(--bash-completion-index $COMP_CWORD)
+
+    for arg in ${COMP_WORDS[@]}; do
+        CMDLINE=(${CMDLINE[@]} --bash-completion-word $arg)
+    done
+
+    COMPREPLY=( $(/home/sam/Documents/IL2232/forsyde-devtools/dist-newstyle/build/x86_64-linux/ghc-9.10.2/forsyde-devtools-0.0.0.1/x/forsyde-devtools-exe/build/forsyde-devtools-exe/forsyde-devtools-exe "${CMDLINE[@]}") )
+}
+
+complete -o filenames -F _forsyde-devtools-exe forsyde-devtools-exe

--- a/.completions/forsyde-devtools-exe/fish
+++ b/.completions/forsyde-devtools-exe/fish
@@ -1,0 +1,19 @@
+ function _forsyde-devtools-exe
+    set -l cl (commandline --tokenize --current-process)
+    # Hack around fish issue #3934
+    set -l cn (commandline --tokenize --cut-at-cursor --current-process)
+    set -l cn (count $cn)
+    set -l tmpline --bash-completion-enriched --bash-completion-index $cn
+    for arg in $cl
+      set tmpline $tmpline --bash-completion-word $arg
+    end
+    for opt in (/home/sam/Documents/IL2232/forsyde-devtools/dist-newstyle/build/x86_64-linux/ghc-9.10.2/forsyde-devtools-0.0.0.1/x/forsyde-devtools-exe/build/forsyde-devtools-exe/forsyde-devtools-exe $tmpline)
+      if test -d $opt
+        echo -E "$opt/"
+      else
+        echo -E "$opt"
+      end
+    end
+end
+
+complete --no-files --command forsyde-devtools-exe --arguments '(_forsyde-devtools-exe)'

--- a/.completions/forsyde-devtools-exe/zsh
+++ b/.completions/forsyde-devtools-exe/zsh
@@ -1,0 +1,32 @@
+#compdef forsyde-devtools-exe
+
+local request
+local completions
+local word
+local index=$((CURRENT - 1))
+
+request=(--bash-completion-enriched --bash-completion-index $index)
+for arg in ${words[@]}; do
+  request=(${request[@]} --bash-completion-word $arg)
+done
+
+IFS=$'\n' completions=($( /home/sam/Documents/IL2232/forsyde-devtools/dist-newstyle/build/x86_64-linux/ghc-9.10.2/forsyde-devtools-0.0.0.1/x/forsyde-devtools-exe/build/forsyde-devtools-exe/forsyde-devtools-exe "${request[@]}" ))
+
+for word in $completions; do
+  local -a parts
+
+  # Split the line at a tab if there is one.
+  IFS=$'\t' parts=($( echo $word ))
+
+  if [[ -n $parts[2] ]]; then
+     if [[ $word[1] == "-" ]]; then
+       local desc=("$parts[1] ($parts[2])")
+       compadd -d desc -- $parts[1]
+     else
+       local desc=($(print -f  "%-019s -- %s" $parts[1] $parts[2]))
+       compadd -l -d desc -- $parts[1]
+     fi
+  else
+    compadd -f -- $word
+  fi
+done

--- a/.completions/forsyde-lsp-exe/bash
+++ b/.completions/forsyde-lsp-exe/bash
@@ -1,0 +1,14 @@
+_forsyde-lsp-exe()
+{
+    local CMDLINE
+    local IFS=$'\n'
+    CMDLINE=(--bash-completion-index $COMP_CWORD)
+
+    for arg in ${COMP_WORDS[@]}; do
+        CMDLINE=(${CMDLINE[@]} --bash-completion-word $arg)
+    done
+
+    COMPREPLY=( $(/home/sam/Documents/IL2232/forsyde-devtools/dist-newstyle/build/x86_64-linux/ghc-9.10.2/forsyde-devtools-0.0.0.1/x/forsyde-lsp-exe/build/forsyde-lsp-exe/forsyde-lsp-exe "${CMDLINE[@]}") )
+}
+
+complete -o filenames -F _forsyde-lsp-exe forsyde-lsp-exe

--- a/.completions/forsyde-lsp-exe/fish
+++ b/.completions/forsyde-lsp-exe/fish
@@ -1,0 +1,19 @@
+ function _forsyde-lsp-exe
+    set -l cl (commandline --tokenize --current-process)
+    # Hack around fish issue #3934
+    set -l cn (commandline --tokenize --cut-at-cursor --current-process)
+    set -l cn (count $cn)
+    set -l tmpline --bash-completion-enriched --bash-completion-index $cn
+    for arg in $cl
+      set tmpline $tmpline --bash-completion-word $arg
+    end
+    for opt in (/home/sam/Documents/IL2232/forsyde-devtools/dist-newstyle/build/x86_64-linux/ghc-9.10.2/forsyde-devtools-0.0.0.1/x/forsyde-lsp-exe/build/forsyde-lsp-exe/forsyde-lsp-exe $tmpline)
+      if test -d $opt
+        echo -E "$opt/"
+      else
+        echo -E "$opt"
+      end
+    end
+end
+
+complete --no-files --command forsyde-lsp-exe --arguments '(_forsyde-lsp-exe)'

--- a/.completions/forsyde-lsp-exe/zsh
+++ b/.completions/forsyde-lsp-exe/zsh
@@ -1,0 +1,32 @@
+#compdef forsyde-lsp-exe
+
+local request
+local completions
+local word
+local index=$((CURRENT - 1))
+
+request=(--bash-completion-enriched --bash-completion-index $index)
+for arg in ${words[@]}; do
+  request=(${request[@]} --bash-completion-word $arg)
+done
+
+IFS=$'\n' completions=($( /home/sam/Documents/IL2232/forsyde-devtools/dist-newstyle/build/x86_64-linux/ghc-9.10.2/forsyde-devtools-0.0.0.1/x/forsyde-lsp-exe/build/forsyde-lsp-exe/forsyde-lsp-exe "${request[@]}" ))
+
+for word in $completions; do
+  local -a parts
+
+  # Split the line at a tab if there is one.
+  IFS=$'\t' parts=($( echo $word ))
+
+  if [[ -n $parts[2] ]]; then
+     if [[ $word[1] == "-" ]]; then
+       local desc=("$parts[1] ($parts[2])")
+       compadd -d desc -- $parts[1]
+     else
+       local desc=($(print -f  "%-019s -- %s" $parts[1] $parts[2]))
+       compadd -l -d desc -- $parts[1]
+     fi
+  else
+    compadd -f -- $word
+  fi
+done

--- a/.completions/generate_completions.sh
+++ b/.completions/generate_completions.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Script for generating completions for bash/fish/zsh. 
+# Notes:
+# - Needs to be ran if arguments modules are changed!
+# - Has to be ran from the root folder!!!
+
+# For compiler:
+forsyde-devtools-exe --bash-completion-script `which forsyde-devtools-exe` > ./.completions/forsyde-devtools-exe/bash
+forsyde-devtools-exe --fish-completion-script `which forsyde-devtools-exe` > ./.completions/forsyde-devtools-exe/fish
+forsyde-devtools-exe --zsh-completion-script `which forsyde-devtools-exe` > ./.completions/forsyde-devtools-exe/zsh
+
+# For LSP:
+forsyde-lsp-exe --bash-completion-script `which forsyde-lsp-exe` > ./.completions/forsyde-lsp-exe/bash
+forsyde-lsp-exe --fish-completion-script `which forsyde-lsp-exe` > ./.completions/forsyde-lsp-exe/fish
+forsyde-lsp-exe --zsh-completion-script `which forsyde-lsp-exe` > ./.completions/forsyde-lsp-exe/zsh

--- a/flake.nix
+++ b/flake.nix
@@ -72,8 +72,16 @@
           ];
           nativeBuildInputs = [ hspkgs.ghc ];
           shellHook = ''
+            # Add compiler and LSP executable paths to PATH. Pre-requisite for completion to work, also just
+            # nice to be able to write forsyde-devtools-exe with completion instead of having cabal exec/run
+            export PATH=$PATH:$(pwd)/dist-newstyle/build/x86_64-linux/ghc-9.10.2/forsyde-devtools-0.0.0.1/x/forsyde-devtools-exe/build/forsyde-devtools-exe/ 
+            export PATH=$PATH:$(pwd)/dist-newstyle/build/x86_64-linux/ghc-9.10.2/forsyde-devtools-0.0.0.1/x/forsyde-lsp-exe/build/forsyde-lsp-exe/
+            # Add completion script
+            source .completions/forsyde-devtools-exe/$0
+            source .completions/forsyde-lsp-exe/$0
+            # Setup pre-commit hook
             cp .githooks/* .git/hooks/
-            chmod +x .git/hooks/*
+            chmod u+x .git/hooks/*
           '';
         };
         packages.default = pkgs.forsyde-devtools;

--- a/src/ArgumentsLSP.hs
+++ b/src/ArgumentsLSP.hs
@@ -43,6 +43,7 @@ inputFile =
     (InputFile <$> str)
     ( metavar "INPUT"
         <> value FromClient
+        <> action "file"
         <> help "Input filename (debug option), if unset get file from client"
     )
 

--- a/src/ArgumentsMain.hs
+++ b/src/ArgumentsMain.hs
@@ -45,6 +45,7 @@ inputFile =
   InputFile
     <$> strArgument
       ( metavar "INPUT"
+          <> action "file"
           <> help "Input filename"
       )
 


### PR DESCRIPTION
Yay I created shell completion! This adds the following:

- `forsyde-devtools-exe` and `forsyde-lsp-exe` to `PATH`. This makes it so you can run `forsyde-devtools-exe` directly without the usage of `cabal exec forsyde-devtools-exe --` and having to manually type that out because `cabal exec` does not tab match.
- Shell completion for bash/fish/zsh for options inside those 2 executables.

## How it works

The file `/.completions/generate_completions.sh` is a bash script that generates completion scripts for bash/fish/zsh automatically. I created this since we might want to have this as a pre-commit hook or an automatic build task in the future so that we don't manually have to rerun it.

Then, in the nix flake I use the following

```sh
# Add completion script
source .completions/forsyde-devtools-exe/$0
source .completions/forsyde-lsp-exe/$0
```
where `$0` retrieves the name of the current shell. This is where I am not entirely sure. If I run this in a "normal terminal" I get for instance:

```
$ echo $0
/bin/bash 
```

but if I run this inside `nix develop` I get:

```
$ echo $0
bash 
```

But if this can only be ran inside nix this should probably be fine? Then it should only be `bash` or `zsh` or `fish` without the `/bin/` part in front of it.

Also, sorry, I couldn't help myself. I changed `chmod +x .git/hooks/*` to `chmod u+x .git/hooks/*` and didn't undo it before I commited, I can edit it back if you want.

## Test
Start with 
```
$ nix develop
```
from the root of `forsyde-devtools`. This should add `forsyde-devtools-exe` and `forsyde-lsp-exe` to `PATH`.
Then, try to enter `forsyde-devtools-exe` by typing
```
forsyde-d<TAB>
```
which should automatically shell complete to `forsyde-devtools-exe`. 
Try that this also works with:
```
forsyde-l<TAB>
```
which should automatically shell complete to `forsyde-lsp-exe`.
Then, try to complete some options in the executable such as `--output-forsyde-ir` with
```
forsyde-d<TAB> --output-f<TAB>
```
which should complete to `forsyde-devtools-exe --output-forsyde-ir`.

Also, try that it works for the LSP with:

```
forsyde-l<TAB> --p<TAB>
```
which should complete to `forsyde-lsp-exe --port`.