### PR TITLE
Get variable name without pretty-printing it, take 2

### DIFF
--- a/src/CoreIRToForSyDeIR.hs
+++ b/src/CoreIRToForSyDeIR.hs
@@ -5,7 +5,6 @@ import Data.List (elemIndex)
 import ForSyDeIR
 import GHC hiding (targetId)
 import GHC.Core
-import GHC.Driver.Ppr
 import GHC.Types.Literal
 
 -- | The `TranslationContext` is a data type which is used to pass around
@@ -14,14 +13,14 @@ import GHC.Types.Literal
 -- and functions whilst they are being built during the translation.
 data TranslationContext = TranslationContext
   { flags :: DynFlags, -- Stores `DynFlags` for safely obtaining strings
-    constructors :: [(String, IRConstructor)], -- Associated list of pcIds and IRConstructors
-    signals :: [(String, IRSignal)], -- Associated list of signalIds and IRSignals
-    functions :: [(String, IRFunction)], -- Associated list of functionIds and IRFunctions
-    systemInputs :: [String], -- List of global inputs to net list
-    systemOutputs :: [String], -- List of global outputs to net list
+    constructors :: [(IRId, IRConstructor)], -- Associated list of pcIds and IRConstructors
+    signals :: [(IRId, IRSignal)], -- Associated list of signalIds and IRSignals
+    functions :: [(IRId, IRFunction)], -- Associated list of functionIds and IRFunctions
+    systemInputs :: [IRId], -- List of global inputs to net list
+    systemOutputs :: [IRId], -- List of global outputs to net list
     nameCounter :: Int, -- Counter used for naming signals
-    pcRates :: [(String, ([Int], [Int]))], -- Associated list of pcIds and input and ouput rates
-    binders :: [(String, Binder)] -- Associated list of binderIds and Binders
+    pcRates :: [(IRId, ([Int], [Int]))], -- Associated list of pcIds and input and ouput rates
+    binders :: [(IRId, Binder)] -- Associated list of binderIds and Binders
   }
 
 -- | `Binder` is a data type used to represent what a `CoreBndr` is associated
@@ -31,8 +30,8 @@ data TranslationContext = TranslationContext
 -- associated with a multi-output process constructor and the index identifies
 -- a specific output.
 data Binder
-  = PcId String
-  | Binding String Int
+  = PcId IRId
+  | Binding IRId Int
 
 initialTranslationContext :: DynFlags -> TranslationContext
 initialTranslationContext dflags =
@@ -51,7 +50,7 @@ initialTranslationContext dflags =
 -- | Translates a `CoreProgram` into an `IRSystem` requires `DynFlags` to
 -- safely convert GHC Core elements into strings. Starts with an empty
 -- `TranslationContext`.
-translateCoreProgram :: DynFlags -> CoreProgram -> (IRSystem, [(String, IRSignal)])
+translateCoreProgram :: DynFlags -> CoreProgram -> (IRSystem, [(IRId, IRSignal)])
 translateCoreProgram dflags program =
   let finalContext = foldl translateCoreBind (initialTranslationContext dflags) program
    in ( IRSystem
@@ -64,7 +63,7 @@ translateCoreProgram dflags program =
 
 -- | Translates a top level `CoreBind`. Module information is currently ignored.
 translateCoreBind :: TranslationContext -> CoreBind -> TranslationContext
-translateCoreBind context (NonRec b e) = case (showPpr (flags context) b) of
+translateCoreBind context (NonRec b e) = case show (IRVar b) of
   "$trModule" -> context
   "system" -> translateSystem context e
   _ -> translateCoreExpr context b e
@@ -78,7 +77,7 @@ translateCoreBind _ (Rec _) = error "translateCoreBind - `Rec` used in top level
 translateSystem :: TranslationContext -> CoreExpr -> TranslationContext
 translateSystem initialContext expr = case expr of
   Lam b e ->
-    let newInput = showPpr (flags initialContext) b
+    let newInput = IRVar b
         context1 = initialContext {systemInputs = newInput : (systemInputs initialContext)}
         context2 = translateSystem context1 e
      in context2
@@ -140,7 +139,7 @@ translateSystemOutputs initialContext expr = case expr of
 
 updateSystemOutput :: TranslationContext -> Id -> TranslationContext
 updateSystemOutput initialContext output =
-  let outputId = showPpr (flags initialContext) output
+  let outputId = IRVar output
       (sourceId, sourceRate) = getSourceFromArgument initialContext outputId
       newSignal = IRSignal outputId (sourceId, sourceRate) (outputId, 1)
       context1 =
@@ -161,7 +160,7 @@ updateConstructorsAndSignals initialContext =
       context1 = aux initialContext initialSignals []
    in context1
   where
-    aux :: TranslationContext -> [IRSignal] -> [(String, IRSignal)] -> TranslationContext
+    aux :: TranslationContext -> [IRSignal] -> [(IRId, IRSignal)] -> TranslationContext
     aux currentContext currentSignals acc = case currentSignals of
       [] ->
         let context1 = currentContext {signals = acc}
@@ -175,7 +174,7 @@ updateConstructorsAndSignals initialContext =
                   -- the index of the output rather than a rate
                   let outputRates = case (lookup pcId (pcRates currentContext)) of
                         Just (_, rates) -> rates
-                        Nothing -> error ("updateConstructorsAndSignals - No rates found for process constructor: " ++ pcId)
+                        Nothing -> error ("updateConstructorsAndSignals - No rates found for process constructor: " ++ show pcId)
                       newSignal = IRSignal signalId (pcId, outputRates !! sourceRate) (targetId, targetRate)
                       context1 = updateConstructorsOutputs currentContext signalId pcId sourceRate
                    in aux context1 signalsTail ((signalId, newSignal) : acc)
@@ -189,13 +188,13 @@ updateConstructorsAndSignals initialContext =
 -- | Updates the outputs constructors within `TranslationContext`. It adds a
 -- signal to the output list of a specific process constructor at the specified
 -- index
-updateConstructorsOutputs :: TranslationContext -> String -> String -> Int -> TranslationContext
+updateConstructorsOutputs :: TranslationContext -> IRId -> IRId -> Int -> TranslationContext
 updateConstructorsOutputs initialContext signalId pcId index =
   let newConstructors = map (updateConstructor) (constructors initialContext)
       context1 = initialContext {constructors = newConstructors}
    in context1
   where
-    updateConstructor :: (String, IRConstructor) -> (String, IRConstructor)
+    updateConstructor :: (IRId, IRConstructor) -> (IRId, IRConstructor)
     updateConstructor (currentPcId, currentConstructor) =
       if pcId == currentPcId
         then case currentConstructor of
@@ -216,7 +215,7 @@ translateSystemBinds :: TranslationContext -> [(CoreBndr, CoreExpr)] -> (Transla
 translateSystemBinds initialContext binds = case binds of
   [] -> (initialContext)
   (b, e) : bindTail ->
-    let binderId = showPpr (flags initialContext) b
+    let binderId = IRVar b
         (binder, context1) = translateSystemExpr initialContext e
         context2 = context1 {binders = (binderId, binder) : (binders context1)}
      in translateSystemBinds context2 bindTail
@@ -232,44 +231,44 @@ translateSystemExpr :: TranslationContext -> CoreExpr -> (Binder, TranslationCon
 translateSystemExpr initialContext expr = case expr of
   -- Application of process constructors with 1 input
   App (Var i) (Var a) ->
-    let pcId = showPpr (flags initialContext) i
-        aId = showPpr (flags initialContext) a
+    let pcId = IRVar i
+        aId = IRVar a
         arguments = [aId]
         context1 = createSignalsFromArguments initialContext pcId arguments
         binder = PcId pcId
      in (binder, context1)
   -- Application of process constructors with 2 input
   App (App (Var i) (Var a1)) (Var a2) ->
-    let pcId = showPpr (flags initialContext) i
-        a1Id = showPpr (flags initialContext) a1
-        a2Id = showPpr (flags initialContext) a2
+    let pcId = IRVar i
+        a1Id = IRVar a1
+        a2Id = IRVar a2
         arguments = [a1Id, a2Id]
         context1 = createSignalsFromArguments initialContext pcId arguments
         binder = PcId pcId
      in (binder, context1)
   -- Application of process constructors with 3 input
   App (App (App (Var i) (Var a1)) (Var a2)) (Var a3) ->
-    let pcId = showPpr (flags initialContext) i
-        a1Id = showPpr (flags initialContext) a1
-        a2Id = showPpr (flags initialContext) a2
-        a3Id = showPpr (flags initialContext) a3
+    let pcId = IRVar i
+        a1Id = IRVar a1
+        a2Id = IRVar a2
+        a3Id = IRVar a3
         arguments = [a1Id, a2Id, a3Id]
         context1 = createSignalsFromArguments initialContext pcId arguments
         binder = PcId pcId
      in (binder, context1)
   -- Application of process constructors with 4 input
   App (App (App (App (Var i) (Var a1)) (Var a2)) (Var a3)) (Var a4) ->
-    let pcId = showPpr (flags initialContext) i
-        a1Id = showPpr (flags initialContext) a1
-        a2Id = showPpr (flags initialContext) a2
-        a3Id = showPpr (flags initialContext) a3
-        a4Id = showPpr (flags initialContext) a4
+    let pcId = IRVar i
+        a1Id = IRVar a1
+        a2Id = IRVar a2
+        a3Id = IRVar a3
+        a4Id = IRVar a4
         arguments = [a1Id, a2Id, a3Id, a4Id]
         context1 = createSignalsFromArguments initialContext pcId arguments
         binder = PcId pcId
      in (binder, context1)
   Case (Var i) _ _ alts ->
-    let bindingId = showPpr (flags initialContext) i
+    let bindingId = IRVar i
         index = getIndexFromAlts initialContext alts
         binder = Binding bindingId index
      in (binder, initialContext)
@@ -285,23 +284,23 @@ getIndexFromAlts context alts = case alts of
     let maybeIndex = elemIndex i ids
      in case maybeIndex of
           Just index -> index
-          Nothing -> error ("getIndexFromAlts - Unable to find: " ++ showPpr (flags context) i)
+          Nothing -> error ("getIndexFromAlts - Unable to find: " ++ show (IRVar i))
   _ -> error ("getIndexFromAlts - More than one AltCon:\n" ++ prettyCoreAltList (flags context) alts)
 
 -- | Creates signals based on the arguments of a process constructor. All
 -- signals created with this function have the process constructor as the
 -- target.
-createSignalsFromArguments :: TranslationContext -> String -> [(String)] -> TranslationContext
+createSignalsFromArguments :: TranslationContext -> IRId -> [IRId] -> TranslationContext
 createSignalsFromArguments context pcId arguments =
   -- The input rates of the process constructor are used to determine the
   -- targetRate of created signals, the index for the input is the same as the
   -- current arguments index.
   let inputRates = case (lookup pcId (pcRates context)) of
         Just (rates, _) -> rates
-        Nothing -> error ("createSignalsFromArguments - No rates found for process constructor: " ++ pcId)
+        Nothing -> error ("createSignalsFromArguments - No rates found for process constructor: " ++ show pcId)
    in aux context (reverse arguments) (reverse inputRates)
   where
-    aux :: TranslationContext -> [(String)] -> [Int] -> TranslationContext
+    aux :: TranslationContext -> [IRId] -> [Int] -> TranslationContext
     aux currentContext currentArguments rates = case (currentArguments, rates) of
       ([], _) -> currentContext
       (_, []) -> currentContext
@@ -315,13 +314,13 @@ createSignalsFromArguments context pcId arguments =
 
 -- | Updates the inputs of constructors within a `TranslationContext`. Adds a
 -- signal to the head of a process constructors input signals list.
-updateConstructorsInputs :: TranslationContext -> String -> String -> TranslationContext
+updateConstructorsInputs :: TranslationContext -> IRId -> IRId -> TranslationContext
 updateConstructorsInputs initialContext pcId signalId =
   let newConstructors = map (updateConstructor) (constructors initialContext)
       context1 = initialContext {constructors = newConstructors}
    in context1
   where
-    updateConstructor :: (String, IRConstructor) -> (String, IRConstructor)
+    updateConstructor :: (IRId, IRConstructor) -> (IRId, IRConstructor)
     updateConstructor (currentPcId, currentConstructor) =
       if pcId == currentPcId
         then case currentConstructor of
@@ -339,7 +338,7 @@ updateConstructorsInputs initialContext pcId signalId =
 -- NOTE: If argument does not directly represent a process constructor then a
 -- temporary source is returned. It will have to be updated later by
 -- `updateConstructorsAndSignals` when all binders have been identified.
-getSourceFromArgument :: TranslationContext -> String -> (String, Int)
+getSourceFromArgument :: TranslationContext -> IRId -> (IRId, Int)
 getSourceFromArgument context argument =
   if elem argument (systemInputs context)
     then (argument, 1)
@@ -351,7 +350,7 @@ getSourceFromArgument context argument =
             Just (PcId pcId) ->
               let outputRates = case (lookup pcId (pcRates context)) of
                     Just (_, rates) -> rates
-                    Nothing -> error ("getSourceFromArgument - No rates found for process constructor: " ++ pcId)
+                    Nothing -> error ("getSourceFromArgument - No rates found for process constructor: " ++ show pcId)
                in (pcId, outputRates !! 0)
             -- Argument is associated with a binder which indirectly represents
             -- a process constructor meaning said constructor has multiple
@@ -359,7 +358,7 @@ getSourceFromArgument context argument =
             -- This will be updated later in the translation when all binders
             -- have been identified.
             Just (Binding bindingId index) -> (bindingId, index)
-            Nothing -> error ("getSourceFromArgument - Unable to identify argument as a system input or binder: " ++ argument)
+            Nothing -> error ("getSourceFromArgument - Unable to identify argument as a system input or binder: " ++ show argument)
 
 -- | Creates actors and delays by pattern matching based on the number of
 -- inputs to the top level function, represented by `Lam`, and inputs to the
@@ -371,46 +370,46 @@ getSourceFromArgument context argument =
 translateCoreExpr :: TranslationContext -> CoreBndr -> CoreExpr -> TranslationContext
 translateCoreExpr context binder expr = case expr of
   Lam _ (App (App (App (Var i) _) _) _)
-    | showPpr (flags context) i == "delaySDF" -> createDelaySDF context binder expr
+    | IRVar i == IRString "delaySDF" -> createDelaySDF context binder expr
   Lam _ (App (App (App (App (App (App (Var i) _) _) _) _) _) _)
-    | showPpr (flags context) i == "actor11SDF" -> createActorSDF context Actor11 binder expr
+    | IRVar i == IRString "actor11SDF" -> createActorSDF context Actor11 binder expr
   Lam _ (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _)
-    | showPpr (flags context) i == "actor12SDF" -> createActorSDF context Actor12 binder expr
+    | IRVar i == IRString "actor12SDF" -> createActorSDF context Actor12 binder expr
   Lam _ (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _)
-    | showPpr (flags context) i == "actor13SDF" -> createActorSDF context Actor13 binder expr
+    | IRVar i == IRString "actor13SDF" -> createActorSDF context Actor13 binder expr
   Lam _ (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _)
-    | showPpr (flags context) i == "actor14SDF" -> createActorSDF context Actor14 binder expr
+    | IRVar i == IRString "actor14SDF" -> createActorSDF context Actor14 binder expr
   Lam _ (Lam _ (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _))
-    | showPpr (flags context) i == "actor21SDF" -> createActorSDF context Actor21 binder expr
+    | IRVar i == IRString "actor21SDF" -> createActorSDF context Actor21 binder expr
   Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _))
-    | showPpr (flags context) i == "actor22SDF" -> createActorSDF context Actor22 binder expr
+    | IRVar i == IRString "actor22SDF" -> createActorSDF context Actor22 binder expr
   Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _))
-    | showPpr (flags context) i == "actor23SDF" -> createActorSDF context Actor23 binder expr
+    | IRVar i == IRString "actor23SDF" -> createActorSDF context Actor23 binder expr
   Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _))
-    | showPpr (flags context) i == "actor24SDF" -> createActorSDF context Actor24 binder expr
+    | IRVar i == IRString "actor24SDF" -> createActorSDF context Actor24 binder expr
   Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _)))
-    | showPpr (flags context) i == "actor31SDF" -> createActorSDF context Actor31 binder expr
+    | IRVar i == IRString "actor31SDF" -> createActorSDF context Actor31 binder expr
   Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _)))
-    | showPpr (flags context) i == "actor32SDF" -> createActorSDF context Actor32 binder expr
+    | IRVar i == IRString "actor32SDF" -> createActorSDF context Actor32 binder expr
   Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _) _)))
-    | showPpr (flags context) i == "actor33SDF" -> createActorSDF context Actor33 binder expr
+    | IRVar i == IRString "actor33SDF" -> createActorSDF context Actor33 binder expr
   Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _) _) _)))
-    | showPpr (flags context) i == "actor34SDF" -> createActorSDF context Actor34 binder expr
+    | IRVar i == IRString "actor34SDF" -> createActorSDF context Actor34 binder expr
   Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _) _))))
-    | showPpr (flags context) i == "actor41SDF" -> createActorSDF context Actor41 binder expr
+    | IRVar i == IRString "actor41SDF" -> createActorSDF context Actor41 binder expr
   Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _) _) _))))
-    | showPpr (flags context) i == "actor42SDF" -> createActorSDF context Actor42 binder expr
+    | IRVar i == IRString "actor42SDF" -> createActorSDF context Actor42 binder expr
   Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _) _) _) _))))
-    | showPpr (flags context) i == "actor43SDF" -> createActorSDF context Actor43 binder expr
+    | IRVar i == IRString "actor43SDF" -> createActorSDF context Actor43 binder expr
   Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _) _) _) _) _))))
-    | showPpr (flags context) i == "actor44SDF" -> createActorSDF context Actor44 binder expr
+    | IRVar i == IRString "actor44SDF" -> createActorSDF context Actor44 binder expr
   _ -> createFunction context binder expr
 
 createDelaySDF :: TranslationContext -> CoreBndr -> CoreExpr -> TranslationContext
 createDelaySDF context binder expr =
   let tokens = (getLits expr [])
-      delayId = showPpr (flags context) binder
-      newDelay = IRDelay delayId tokens ("", "")
+      delayId = IRVar binder
+      newDelay = IRDelay delayId tokens (Empty, Empty)
       newActorsList = (delayId, ([1], [1])) : (pcRates context)
    in context {constructors = (delayId, newDelay) : (constructors context), pcRates = newActorsList}
 
@@ -422,8 +421,8 @@ createActorSDF initialContext actorType binder expr =
         Nothing -> error "createActorSDF - No function found for actor"
         Just functionName ->
           let (inputRates, outputRates) = splitAt (getActorSplit actorType) lits
-              actorId = showPpr (flags initialContext) binder
-              baseOutputs = replicate (length outputRates) ""
+              actorId = IRVar binder
+              baseOutputs = replicate (length outputRates) Empty
               newActor = IRActor actorId actorType functionName ([], baseOutputs)
               newActors = (actorId, (inputRates, outputRates)) : (pcRates initialContext)
               newConstructors = (actorId, newActor) : (constructors initialContext)
@@ -463,13 +462,13 @@ getActorSplit actorType = case actorType of
 
 createFunction :: TranslationContext -> CoreBndr -> CoreExpr -> TranslationContext
 createFunction context binder expr =
-  let functionId = showPpr (flags context) binder
+  let functionId = IRVar binder
       newFunction = IRFunction functionId (Just expr)
    in context {functions = (functionId, newFunction) : (functions context)}
 
 -- | Helper function for `createActorSDF` which returns name of the function
 -- used by the process constructor.
-getFunctionName :: TranslationContext -> CoreExpr -> Maybe String
+getFunctionName :: TranslationContext -> CoreExpr -> Maybe IRId
 getFunctionName context expr = case expr of
   App e a ->
     let getFirst = getFunctionName context a
@@ -479,7 +478,7 @@ getFunctionName context expr = case expr of
   Lam _ e -> getFunctionName context e
   Let _ e -> getFunctionName context e
   Var v ->
-    let name = showPpr (flags context) v
+    let name = IRVar v
      in if any (\x -> case x of IRFunction functionName _ -> functionName == name) (map snd (functions context))
           then
             Just name

--- a/src/ForSyDeIR.hs
+++ b/src/ForSyDeIR.hs
@@ -11,6 +11,7 @@ module ForSyDeIR
     prettyIRFunction,
     prettyIRSystem,
     prettyIRJSON,
+    IRId (..),
   )
 where
 
@@ -25,9 +26,32 @@ import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TLB
 import GHC (DynFlags)
 import GHC.Core
+import GHC.Plugins (Var, nameOccName, occNameString, varName, varUnique)
 import Text.Printf (printf)
 
 -- ForSyDe IR data types
+
+data IRId
+  = IRVar Var
+  | IRString String
+  | Empty
+
+instance Show IRId where
+  show (IRVar i) = occNameString $ nameOccName $ varName i
+  show (IRString s) = s
+  show Empty = ""
+
+instance Eq IRId where
+  (==) (IRVar a) (IRVar b) = varUnique a == varUnique b
+  (==) (IRString a) (IRString b) = a == b
+  -- NOTE: This implies Empty is not equal to empty
+  (==) Empty _ = False
+  (==) _ Empty = False
+  (==) (IRString a) b = a == show b
+  (==) a (IRString b) = show a == b
+
+prettyIRId :: IRId -> String
+prettyIRId = show . show
 
 data ActorType
   = Actor11
@@ -51,17 +75,17 @@ data ActorType
 -- IRDelay(delayId, tokens, (inputSignal, outputSignal))
 -- IRActor(actorId, actorType, (inputSignals, outputSignals))
 data IRConstructor
-  = IRDelay String [Int] (String, String)
-  | IRActor String ActorType String ([String], [String])
+  = IRDelay IRId [Int] (IRId, IRId)
+  | IRActor IRId ActorType IRId ([IRId], [IRId])
 
 -- IRSignal(signalId (sourceId, sourceRate) (targetId, targetRate))
-data IRSignal = IRSignal String (String, Int) (String, Int)
+data IRSignal = IRSignal IRId (IRId, Int) (IRId, Int)
 
 -- IRFunction(functionId, maybe function)
-data IRFunction = IRFunction String (Maybe CoreExpr)
+data IRFunction = IRFunction IRId (Maybe CoreExpr)
 
 -- IRSystem((globalInputs, globalOutputs), constructors, signals, functions)
-data IRSystem = IRSystem ([String], [String]) [IRConstructor] [IRSignal] [IRFunction]
+data IRSystem = IRSystem ([IRId], [IRId]) [IRConstructor] [IRSignal] [IRFunction]
 
 -- ForSyDe IR pretty printing functions
 
@@ -70,30 +94,36 @@ indent numberSpaces = unlines . map (replicate numberSpaces ' ' ++) . lines
 
 prettyIRSignal :: IRSignal -> String
 prettyIRSignal (IRSignal signalId (inputId, inputRate) (outputId, outputRate)) =
-  printf "IRSignal(\"%s\", (\"%s\", %d), (\"%s\", %d))" signalId inputId inputRate outputId outputRate
+  printf
+    "IRSignal(\"%s\", (\"%s\", %d), (\"%s\", %d))"
+    (show signalId)
+    (show inputId)
+    inputRate
+    (show outputId)
+    outputRate
 
 prettyIRConstructor :: IRConstructor -> String
 prettyIRConstructor (IRDelay delayId tokens (input, output)) =
   printf
     "IRDelay(\"%s\", {%s}, %s, %s)"
-    delayId
+    (show delayId)
     (intercalate ", " (map show tokens))
-    (show input)
-    (show output)
+    (prettyIRId input)
+    (prettyIRId output)
 prettyIRConstructor (IRActor actorId actorType functionId (inputs, outputs)) =
   printf
     "IRActor(\"%s\", %s, \"%s\", {%s}, {%s})"
-    actorId
+    (show actorId)
     (show actorType)
-    functionId
-    (intercalate ", " (map show inputs))
-    (intercalate ", " (map show outputs))
+    (show functionId)
+    (intercalate ", " (map prettyIRId inputs))
+    (intercalate ", " (map prettyIRId outputs))
 
 prettyIRFunction :: DynFlags -> IRFunction -> String
 prettyIRFunction dflags (IRFunction functionId function) =
   printf
     "IRFunction(\"%s\", %s)"
-    functionId
+    (show functionId)
     (maybe "" (prettyFunction dflags) function)
 
 prettyFunction :: DynFlags -> CoreExpr -> String
@@ -103,8 +133,8 @@ prettyIRSystem :: DynFlags -> IRSystem -> String
 prettyIRSystem dflags (IRSystem (inputs, outputs) constructors signals functions) =
   printf
     "IRSystem(\n  {%s}, {%s},\n  {\n%s  },\n  {\n%s  },\n  {\n%s  }\n)\n"
-    (intercalate ", " (map show inputs))
-    (intercalate ", " (map show outputs))
+    (intercalate ", " (map prettyIRId inputs))
+    (intercalate ", " (map prettyIRId outputs))
     (indent 4 (intercalate ",\n" (map prettyIRConstructor constructors)))
     (indent 4 (intercalate ",\n" (map prettyIRSignal signals)))
     (indent 4 (intercalate ",\n" (map (prettyIRFunction dflags) functions)))
@@ -118,28 +148,28 @@ instance ToJSON IRConstructor where
   toJSON (IRDelay name tokens (_, _)) =
     object
       [ "type" .= Text.pack "Delay",
-        "name" .= Text.pack name,
+        "name" .= Text.pack (show name),
         "tokens" .= Seq.fromList tokens
       ]
   toJSON (IRActor name ty func (_, _)) =
     object
       [ "type" .= Text.pack (show ty),
-        "name" .= Text.pack name,
-        "function" .= Text.pack func
+        "name" .= Text.pack (show name),
+        "function" .= Text.pack (show func)
       ]
 
 instance ToJSON IRSignal where
   toJSON (IRSignal name (source, sourceRate) (target, targetRate)) =
     object
-      [ "name" .= Text.pack name,
+      [ "name" .= Text.pack (show name),
         "source"
           .= object
-            [ "name" .= Text.pack source,
+            [ "name" .= Text.pack (show source),
               "rate" .= sourceRate
             ],
         "target"
           .= object
-            [ "name" .= Text.pack target,
+            [ "name" .= Text.pack (show target),
               "rate" .= targetRate
             ]
       ]
@@ -147,7 +177,7 @@ instance ToJSON IRSignal where
 instance ToJSON IRFunction where
   toJSON (IRFunction name _) =
     object
-      [ "name" .= Text.pack name
+      [ "name" .= Text.pack (show name)
       -- "coreexpr" .= ...
       ]
 
@@ -156,8 +186,8 @@ instance ToJSON IRSystem where
     object
       [ "system"
           .= object
-            [ "inputs" .= Seq.fromList inputs,
-              "outputs" .= Seq.fromList outputs,
+            [ "inputs" .= Seq.fromList (map Text.show inputs),
+              "outputs" .= Seq.fromList (map Text.show outputs),
               "processes" .= Seq.fromList processes,
               "signals" .= Seq.fromList signals,
               "functions" .= Seq.fromList functions

--- a/src/ForSyDeIRToProceduralIR.hs
+++ b/src/ForSyDeIRToProceduralIR.hs
@@ -12,21 +12,21 @@ import ProceduralIR
 -- ProceduralIR.
 data TranslationContext = TranslationContext
   { flags :: DynFlags, -- Stores `DynFlags` for safely obtaining strings
-    lookupSignals :: [(String, IRSignal)],
-    actors :: [(String, [Statement])], -- Associated list of actor ids and statements
-    signals :: [(String, Statement)], -- Associated list of signal ids and statement
+    lookupSignals :: [(IRId, IRSignal)],
+    actors :: [(IRId, [Statement])], -- Associated list of actor ids and statements
+    signals :: [(IRId, Statement)], -- Associated list of signal ids and statement
     ioTokens :: [Statement], -- List of statements for input/output tokens
     initBuffers :: [Statement], -- List of statements for initialising signal buffers
     freeBuffers :: [Statement], -- List of statements for freeing signal buffers
-    systemInputs :: [String], -- List of system inputs
-    systemOutputs :: [String], -- List of system outputs
-    delayBuffers :: [(String, String)], -- Associated list of signal ids and buffer name for delay signals
+    systemInputs :: [IRId], -- List of system inputs
+    systemOutputs :: [IRId], -- List of system outputs
+    delayBuffers :: [(IRId, IRId)], -- Associated list of signal ids and buffer name for delay signals
     initDelay :: [Statement], -- List of statements for initialising delay tokens
     initFunctions :: [Global],
     functions :: [Global]
   }
 
-initialTranslationContext :: DynFlags -> [(String, IRSignal)] -> [String] -> [String] -> [(String, String)] -> TranslationContext
+initialTranslationContext :: DynFlags -> [(IRId, IRSignal)] -> [IRId] -> [IRId] -> [(IRId, IRId)] -> TranslationContext
 initialTranslationContext dflags lookupSignalList inputList outputList delayBufferList =
   TranslationContext
     { flags = dflags,
@@ -47,7 +47,7 @@ initialTranslationContext dflags lookupSignalList inputList outputList delayBuff
 -- | Translates a ForSyDe IR `IRSystem` into a Procedural IR `Program`. Requires
 -- the schedule, buffer, and delay buffer lists from the SDF scheduler as an
 -- input. Also requires an associated list of signals for lookups.
-translateIRSystemToProgram :: DynFlags -> [String] -> [(String, Int)] -> [(String, String)] -> [(String, IRSignal)] -> IRSystem -> Program
+translateIRSystemToProgram :: DynFlags -> [IRId] -> [(IRId, Int)] -> [(IRId, IRId)] -> [(IRId, IRSignal)] -> IRSystem -> Program
 translateIRSystemToProgram dflags scheduleList bufferList delayBufferList lookupSignalList (IRSystem (inputList, outputList) constructors _signalList functionList) =
   let initialContext = initialTranslationContext dflags lookupSignalList inputList outputList delayBufferList
       context1 = foldl' translateIRConstructor initialContext constructors
@@ -57,7 +57,7 @@ translateIRSystemToProgram dflags scheduleList bufferList delayBufferList lookup
    in Prog (reverse (initFunctions context3) ++ [main] ++ reverse (functions context3))
 
 -- | Translates the `TranslationContext` and Schedule into a main function.
-translateContextToMain :: TranslationContext -> [String] -> Global
+translateContextToMain :: TranslationContext -> [IRId] -> Global
 translateContextToMain context scheduleList =
   let scheduledStmts = scheduleActors context scheduleList
       whileStmt = SWhile (EInt 1) (SScope scheduledStmts)
@@ -70,14 +70,14 @@ translateContextToMain context scheduleList =
 -- on a provided Schedule. Note that actor function call statements include
 -- the associated minimum runtime enviorment statements for interacting with
 -- standard in and out.
-scheduleActors :: TranslationContext -> [String] -> [Statement]
+scheduleActors :: TranslationContext -> [IRId] -> [Statement]
 scheduleActors context scheduleList = foldl' foldSchedule [] scheduleList
   where
-    foldSchedule :: [Statement] -> String -> [Statement]
+    foldSchedule :: [Statement] -> IRId -> [Statement]
     foldSchedule acc actorId =
       let actorStmts = case lookup actorId (actors context) of
             Just stmts -> stmts
-            Nothing -> error ("schedule - actor not found: " ++ actorId)
+            Nothing -> error ("schedule - actor not found: " ++ show actorId)
        in (acc ++ actorStmts)
 
 -- | Translates a component of the buffer size list provided by the SDF
@@ -85,18 +85,18 @@ scheduleActors context scheduleList = foldl' foldSchedule [] scheduleList
 -- statement which are used to update the `TranslationContext`. Note that io
 -- token statements are only created for buffers which relate to with system
 -- inputs and outputs.
-translateBuffer :: TranslationContext -> (String, Int) -> TranslationContext
+translateBuffer :: TranslationContext -> (IRId, Int) -> TranslationContext
 translateBuffer initialContext (bufferId, bufferSize) =
-  let initStmt = SVarDef (TPointer (TIdent "buffer_nonblocking")) bufferId (ECall "buffer_nonblocking_new" [EInt bufferSize])
-      freeStmt = SExpr (ECall "buffer_nonblocking_free" [EVar bufferId])
+  let initStmt = SVarDef (TPointer (TIdent "buffer_nonblocking")) (show bufferId) (ECall "buffer_nonblocking_new" [EInt bufferSize])
+      freeStmt = SExpr (ECall "buffer_nonblocking_free" [EVar $ show bufferId])
    in if (elem bufferId (systemInputs initialContext))
         then
-          let ioTokenStmt = SArrayDecl TInt ("input_" ++ bufferId) [EInt bufferSize]
+          let ioTokenStmt = SArrayDecl TInt ("input_" ++ show bufferId) [EInt bufferSize]
            in initialContext {ioTokens = ioTokenStmt : ioTokens initialContext, initBuffers = initStmt : initBuffers initialContext, freeBuffers = freeStmt : freeBuffers initialContext}
         else
           if (elem bufferId (systemOutputs initialContext))
             then
-              let ioTokenStmt = SVarDecl TInt ("output_" ++ bufferId)
+              let ioTokenStmt = SVarDecl TInt ("output_" ++ show bufferId)
                in initialContext {ioTokens = ioTokenStmt : ioTokens initialContext, initBuffers = initStmt : initBuffers initialContext, freeBuffers = freeStmt : freeBuffers initialContext}
             else
               initialContext {initBuffers = initStmt : initBuffers initialContext, freeBuffers = freeStmt : freeBuffers initialContext}
@@ -113,11 +113,11 @@ translateIRConstructor initialContext constructor = case constructor of
           Just bufferId ->
             let foldDelayTokens :: [Statement] -> Int -> [Statement]
                 foldDelayTokens acc token =
-                  let stmt = SExpr (ECall "write_token" [EVar bufferId, EInt token])
+                  let stmt = SExpr (ECall "write_token" [EVar $ show bufferId, EInt token])
                    in (stmt : acc)
                 delayStmts = (foldl' foldDelayTokens [] tokens)
              in initialContext {initDelay = delayStmts ++ initDelay initialContext}
-          Nothing -> error ("translateIRConstructor - delay buffer not found for signals: " ++ inputSignal ++ ", " ++ outputSignal)
+          Nothing -> error ("translateIRConstructor - delay buffer not found for signals: " ++ show inputSignal ++ ", " ++ show outputSignal)
   IRActor actorId actorType functionId (inputSignals, outputSignals) ->
     -- `IRActor` results in a statement calling an SDF actor function within
     -- source rates, target rates, and a function as arguments.
@@ -132,9 +132,9 @@ translateIRConstructor initialContext constructor = case constructor of
                 actorName
                 ( (map (\rate -> EInt (fromIntegral rate)) inputRates)
                     ++ (map (\rate -> EInt (fromIntegral rate)) outputRates)
-                    ++ (map (\bufferId -> EVar bufferId) translatedInputSignals)
-                    ++ (map (\bufferId -> EVar bufferId) translatedOutputSignals)
-                    ++ [EVar functionId]
+                    ++ (map (\bufferId -> EVar $ show bufferId) translatedInputSignals)
+                    ++ (map (\bufferId -> EVar $ show bufferId) translatedOutputSignals)
+                    ++ [EVar $ show functionId]
                 )
             )
         inputStmts = foldl' foldActorSignals [] inputSignals
@@ -146,12 +146,12 @@ translateIRConstructor initialContext constructor = case constructor of
     -- Helper function used to update a signal id into its respecitve signal
     -- buffer id. There is only a difference in the translation for signals
     -- which are source and targets of delays.
-    translateSignalId :: TranslationContext -> String -> String
+    translateSignalId :: TranslationContext -> IRId -> IRId
     translateSignalId context signalId =
       case lookup signalId (delayBuffers context) of
         Just bufferId -> bufferId
         Nothing -> signalId
-    foldActorSignals :: [Statement] -> String -> [Statement]
+    foldActorSignals :: [Statement] -> IRId -> [Statement]
     foldActorSignals acc signalId =
       if (elem signalId (systemInputs initialContext))
         then
@@ -164,14 +164,14 @@ translateIRConstructor initialContext constructor = case constructor of
                   (SVarDef TInt "i" (EInt 0))
                   (EBinOp Less (EVar "i") (EInt (bufferSize)))
                   (SExpr (EUnOp Increment (EVar "i")))
-                  (SScope [SVarAssign "status" (ECall "scanf" [EString "%d", EReference (EArrayAccess (EVar ("input_" ++ signalId)) (EVar "i"))])])
+                  (SScope [SVarAssign "status" (ECall "scanf" [EString "%d", EReference (EArrayAccess (EVar ("input_" ++ show signalId)) (EVar "i"))])])
               breakIfStmt = SIf (EBinOp Less (EVar "status") (EInt 1)) (SBreak) Nothing
               writeForStmt =
                 SFor
                   (SVarDef TInt "i" (EInt 0))
                   (EBinOp Less (EVar "i") (EInt (bufferSize)))
                   (SExpr (EUnOp Increment (EVar "i")))
-                  (SScope [SExpr (ECall "write_token" [EVar signalId, EArrayAccess (EVar ("input_" ++ signalId)) (EVar "i")])])
+                  (SScope [SExpr (ECall "write_token" [EVar $ show signalId, EArrayAccess (EVar ("input_" ++ show signalId)) (EVar "i")])])
            in (writeForStmt : breakIfStmt : scanForStmt : acc)
         else
           if (elem signalId (systemOutputs initialContext))
@@ -182,8 +182,8 @@ translateIRConstructor initialContext constructor = case constructor of
                   -- outputs to standard out.
                   scopeStmt =
                     SScope
-                      [ SExpr (ECall "read_token" [EVar signalId, EReference (EVar ("output_" ++ signalId))]),
-                        SExpr (ECall "printf" [EString "%d", EVar ("output_" ++ signalId)])
+                      [ SExpr (ECall "read_token" [EVar $ show signalId, EReference (EVar ("output_" ++ show signalId))]),
+                        SExpr (ECall "printf" [EString "%d", EVar ("output_" ++ show signalId)])
                       ]
                   forStmt =
                     SFor
@@ -215,19 +215,19 @@ translateActorType actorType = case actorType of
   Actor43 -> "actor43SDF"
   Actor44 -> "actor44SDF"
 
-getSourceRate :: TranslationContext -> String -> Int
+getSourceRate :: TranslationContext -> IRId -> Int
 getSourceRate context signalId =
   let signal = lookup signalId (lookupSignals context)
    in case signal of
         Just (IRSignal _ (_, rate) _) -> rate
-        Nothing -> error ("getSourceRate - signal not found: " ++ signalId)
+        Nothing -> error ("getSourceRate - signal not found: " ++ show signalId)
 
-getTargetRate :: TranslationContext -> String -> Int
+getTargetRate :: TranslationContext -> IRId -> Int
 getTargetRate context signalId =
   let signal = lookup signalId (lookupSignals context)
    in case signal of
         Just (IRSignal _ _ (_, rate)) -> rate
-        Nothing -> error ("getTargetRate - signal not found: " ++ signalId)
+        Nothing -> error ("getTargetRate - signal not found: " ++ show signalId)
 
 translateIRFunctionToGlobals :: TranslationContext -> IRFunction -> TranslationContext
 translateIRFunctionToGlobals currentContext (IRFunction functionId maybeFunction) = case maybeFunction of
@@ -239,18 +239,20 @@ translateIRFunctionToGlobals currentContext (IRFunction functionId maybeFunction
 
 -- The following is a temporary hard coded solution that translates the inputs
 -- of the `add` and `accummulate` functions from SDF example 8.
-translateCoreExprToGlobals :: TranslationContext -> String -> CoreExpr -> (Global, Global)
+translateCoreExprToGlobals :: TranslationContext -> IRId -> CoreExpr -> (Global, Global)
 translateCoreExprToGlobals context binder expr = case (binder, expr) of
-  ("accumulate", Lam _ (Lam _ e)) ->
-    let functionScopeStmt = translateCoreExprToStatement context e
-        initFunctionGlobal = GFuncDeclare (Just Static) TVoid (binder) [(TPointer TInt, "input_1"), (TPointer TInt, "input_2"), (TPointer TInt, "output_1"), (TPointer TInt, "output_2")]
-        functionGlobal = GFuncDef (Just Static) TVoid (binder) [(TPointer TInt, "input_1"), (TPointer TInt, "input_2"), (TPointer TInt, "output_1"), (TPointer TInt, "output_2")] functionScopeStmt
-     in (initFunctionGlobal, functionGlobal)
-  ("add", Lam _ (Lam _ e)) ->
-    let functionScopeStmt = translateCoreExprToStatement context e
-        initFunctionGlobal = GFuncDeclare (Just Static) TVoid (binder) [(TPointer TInt, "input_1"), (TPointer TInt, "input_2"), (TPointer TInt, "output")]
-        functionGlobal = GFuncDef (Just Static) TVoid (binder) [(TPointer TInt, "input_1"), (TPointer TInt, "input_2"), (TPointer TInt, "output")] functionScopeStmt
-     in (initFunctionGlobal, functionGlobal)
+  (b, Lam _ (Lam _ e))
+    | b == IRString "accumulate" ->
+        let functionScopeStmt = translateCoreExprToStatement context e
+            initFunctionGlobal = GFuncDeclare (Just Static) TVoid (show binder) [(TPointer TInt, "input_1"), (TPointer TInt, "input_2"), (TPointer TInt, "output_1"), (TPointer TInt, "output_2")]
+            functionGlobal = GFuncDef (Just Static) TVoid (show binder) [(TPointer TInt, "input_1"), (TPointer TInt, "input_2"), (TPointer TInt, "output_1"), (TPointer TInt, "output_2")] functionScopeStmt
+         in (initFunctionGlobal, functionGlobal)
+  (b, Lam _ (Lam _ e))
+    | b == IRString "add" ->
+        let functionScopeStmt = translateCoreExprToStatement context e
+            initFunctionGlobal = GFuncDeclare (Just Static) TVoid (show binder) [(TPointer TInt, "input_1"), (TPointer TInt, "input_2"), (TPointer TInt, "output")]
+            functionGlobal = GFuncDef (Just Static) TVoid (show binder) [(TPointer TInt, "input_1"), (TPointer TInt, "input_2"), (TPointer TInt, "output")] functionScopeStmt
+         in (initFunctionGlobal, functionGlobal)
   _ -> error ("translateCoreExprToGlobals - unsupported expression:\n" ++ showPpr (flags context) expr)
 
 -- The following is a temporary hard coded solution that translates the

--- a/src/LSP.hs
+++ b/src/LSP.hs
@@ -19,7 +19,6 @@ import Data.Aeson ((.=))
 import qualified Data.Aeson as A
 import Data.Aeson.Encode.Pretty as AP
 import Data.Aeson.KeyMap ((!?))
-import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy.Char8 as BSL8
 import qualified Data.List.NonEmpty as NE
 import Data.Proxy
@@ -49,12 +48,12 @@ forSyDeIRToGraph file (IRSystem (inputs, outputs) actors signals _) = graph
     createPortWithRate pid renderings properties (n, r) =
       createPort' renderings properties [label] (id, r)
       where
-        id = T.concat [pid, "$P", T.pack n]
-        label = KLabel {gid = T.concat [id, "$L0"], label = T.show r}
+        id = pid <> "$P" <> T.show n
+        label = KLabel {gid = id <> "$L0", label = T.show r}
     createPortWithoutRate pid renderings properties (n, r) =
       createPort' renderings properties [] (id, r)
       where
-        id = T.concat [pid, "$P", T.pack n]
+        id = pid <> "$P" <> T.show n
     -- \| Create a port with the passed renderings and children
     createPort' renderings properties children (gid, _) =
       KPort
@@ -75,11 +74,11 @@ forSyDeIRToGraph file (IRSystem (inputs, outputs) actors signals _) = graph
             (NodeSizeConstraints [0, 1, 2, 3]),
             (NodeSizeMinimum [64, 64])
           ]
-      (IRDelay name d _) ->
+      (IRDelay name _ _) ->
         createNode'
           name
           (createPortWithoutRate)
-          Nothing
+          (Nothing :: Maybe IRId)
           [KEllipse [KBackgroundColor 0 0 0]]
           [ (NodeLabelsPlacement [1, 4, 6]),
             (NodeSizeConstraints [3]),
@@ -102,12 +101,12 @@ forSyDeIRToGraph file (IRSystem (inputs, outputs) actors signals _) = graph
     -- \| Helper for createNode and global inputs / outputs
     createNode' name createPort l r p = node
       where
-        nid = T.pack ("$root$N" ++ name)
+        nid = "$root$N" <> T.show name
         insignals = findInputSignals signals name
         outsignals = findOutputSignals signals name
         inports = map (createPort nid (maybe [] (\_l -> [KText "◆" []]) l) []) insignals
         outports = map (createPort nid [] []) outsignals
-        nl = maybe [] (\l -> [KLabel {gid = T.concat [nid, "$L0"], label = T.pack l}]) l
+        nl = maybe [] (\l -> [KLabel {gid = nid <> "$L0", label = T.show l}]) l
         c = inports ++ outports ++ nl
         node =
           KNode
@@ -119,14 +118,14 @@ forSyDeIRToGraph file (IRSystem (inputs, outputs) actors signals _) = graph
     -- \| Create an edge from an IRSignal, depends on port id
     createEdge (IRSignal n (sname, _) (tname, _)) = edge
       where
-        sn = T.concat ["$root$N", T.pack sname, "$P", T.pack n]
-        tn = T.concat ["$root$N", T.pack tname, "$P", T.pack n]
-        name = T.concat [sn, "$E", T.pack n]
-        sigid = T.concat [name, "$L0"]
+        sn = "$root$N" <> T.show sname <> "$P" <> T.show n
+        tn = "$root$N" <> T.show tname <> "$P" <> T.show n
+        name = sn <> "$E" <> T.show n
+        sigid = name <> "$L0"
         children =
           if n == sname || n == tname
             then []
-            else [KLabel {gid = sigid, label = T.pack n}]
+            else [KLabel {gid = sigid, label = T.show n}]
         edge =
           KEdge
             { gid = name,

--- a/src/SDFSchedule.hs
+++ b/src/SDFSchedule.hs
@@ -37,7 +37,7 @@ convertIRSystem (IRSystem (inputNames, outputNames) constructors signals _) =
       findActorByName n =
         case Data.List.find (\a -> name a == n) baseActors of
           Just a -> a
-          Nothing -> error ("Actor not found: " ++ n)
+          Nothing -> error ("Actor not found: " ++ show n)
 
       -- 6. Build normal edges (no delay, no input/output)
       normalEdges =
@@ -70,8 +70,8 @@ convertIRSystem (IRSystem (inputNames, outputNames) constructors signals _) =
                 constructors of
                 Just (IRDelay _ delayInitTokens (_, _)) -> delayInitTokens
                 Just (IRActor _ _ _ _) ->
-                  error $ "Expected delay node but found actor: " ++ delayName -- To eliminate pattern match warning
-                Nothing -> error $ "Delay node " ++ delayName ++ " not found in constructors"
+                  error $ "Expected delay node but found actor: " ++ show delayName -- To eliminate pattern match warning
+                Nothing -> error $ "Delay node " ++ show delayName ++ " not found in constructors"
             incoming =
               [ (signalId, srcId, prodRate)
               | IRSignal signalId (srcId, prodRate) (dstId, _) <- signals,
@@ -85,21 +85,21 @@ convertIRSystem (IRSystem (inputNames, outputNames) constructors signals _) =
          in case (incoming, outgoing) of
               ([(inSignalId, srcIn, prodIn)], [(outSignalId, dstOut, consOut)]) ->
                 [ Edge
-                    (inSignalId ++ "_" ++ outSignalId) -- delay edge names are combined
+                    (IRString $ show inSignalId ++ "_" ++ show outSignalId) -- delay edge names are combined
                     (findActorByName srcIn)
                     (findActorByName dstOut)
                     prodIn
                     consOut
                     True
                     (length delayConstructor)
-                    (Just [(inSignalId, inSignalId ++ "_" ++ outSignalId), (outSignalId, inSignalId ++ "_" ++ outSignalId)])
+                    (Just [(inSignalId, IRString $ show inSignalId ++ "_" ++ show outSignalId), (outSignalId, IRString $ show inSignalId ++ "_" ++ show outSignalId)])
                 ]
               ([], _) ->
-                error $ "Delay node " ++ delayName ++ " has no input signal."
+                error $ "Delay node " ++ show delayName ++ " has no input signal."
               (_, []) ->
-                error $ "Delay node " ++ delayName ++ " has no output signal."
+                error $ "Delay node " ++ show delayName ++ " has no output signal."
               _ ->
-                error $ "Delay node " ++ delayName ++ " must have exactly one input and one output."
+                error $ "Delay node " ++ show delayName ++ " must have exactly one input and one output."
 
       -- 8. Normalize self-loops: ensure prod == cons, otherwise error
       normalizeSelfLoop e@(Edge edgeNameValue srcActor dstActor prodRate consRate _ _ _)
@@ -108,9 +108,9 @@ convertIRSystem (IRSystem (inputNames, outputNames) constructors signals _) =
               then
                 error $
                   "Invalid self-loop on actor "
-                    ++ name srcActor
+                    ++ show (name srcActor)
                     ++ " (edge: "
-                    ++ edgeNameValue
+                    ++ show edgeNameValue
                     ++ ")"
                     ++ ": prod="
                     ++ show prodRate
@@ -127,20 +127,20 @@ convertIRSystem (IRSystem (inputNames, outputNames) constructors signals _) =
 ----------------------------------------------------------
 
 data Actor = Actor
-  { name :: String,
+  { name :: IRId,
     isInput :: Bool
   }
   deriving (Show, Eq, Generic)
 
 data Edge = Edge
-  { edgeName :: String,
+  { edgeName :: IRId,
     src :: Actor,
     dst :: Actor,
     prod :: Int,
     cons :: Int,
     isDelay :: Bool,
     initTokens :: Int, -- Count of Init tokens for delay edges
-    buffers :: Maybe [(String, String)]
+    buffers :: Maybe [(IRId, IRId)]
   }
   deriving (Show, Eq, Generic)
 
@@ -206,18 +206,18 @@ normalizeToInteger v =
 matrixEdgesRowsToString :: [Edge] -> [Actor] -> Matrix R -> String
 matrixEdgesRowsToString edges actors topoMatrix =
   let -- Calculate the maximum width of each column
-      actorNameWidths = map (length . name) actors
+      actorNameWidths = map (length . show . name) actors
       rowValueWidths = map (maximum . map (length . show)) (toLists topoMatrix)
       colWidths = zipWith max actorNameWidths rowValueWidths
       totalColWidths = map (+ 2) colWidths -- Add 2 to each column width for spacing
 
       -- Calculate the maximum width of the edge labels
-      edgeLabelWidth = maximum (map (length . edgeLabel) edges)
+      edgeLabelWidth = maximum (map (length . show . edgeLabel) edges)
 
       -- Build the header
       header =
         pad (edgeLabelWidth + 2) "Edge\\Actor"
-          ++ concatMap (\(actor, width) -> pad width (name actor)) (zip actors totalColWidths)
+          ++ concatMap (\(actor, width) -> pad width (show $ name actor)) (zip actors totalColWidths)
 
       -- Build the separator line
       totalWidth = edgeLabelWidth + 2 + sum totalColWidths
@@ -240,7 +240,7 @@ matrixEdgesRowsToString edges actors topoMatrix =
     edgeLabel edge = edgeName edge
 
     rowToString labelWidth colWidths (edge, rowValues) =
-      pad (labelWidth + 2) (edgeLabel edge)
+      pad (labelWidth + 2) (show $ edgeLabel edge)
         ++ concatMap
           (\(val, width) -> pad width (show val))
           (zip rowValues colWidths)
@@ -347,7 +347,7 @@ greedySchedule actors edges repetitionCounts =
                              [] ->
                                if isInput actor
                                  then True -- If is input actor and no incoming edges from other actors
-                                 else error $ "Invalid graph: actor " ++ name actor ++ " has no incoming edges but is not marked as input."
+                                 else error $ "Invalid graph: actor " ++ show (name actor) ++ " has no incoming edges but is not marked as input."
                              _ ->
                                all
                                  ( \edgeIdx ->
@@ -373,7 +373,7 @@ greedySchedule actors edges repetitionCounts =
 -- The buffer size of each edge is defined as the maximum token count observed
 ----------------------------------------------------------
 
-simulateBufferUsage :: [Actor] -> [Edge] -> [Int] -> [Int] -> [(String, Int)]
+simulateBufferUsage :: [Actor] -> [Edge] -> [Int] -> [Int] -> [(IRId, Int)]
 simulateBufferUsage actors edges initialTokens schedule =
   let -- Get all edge names
       edgeNames = map edgeName edges
@@ -401,7 +401,7 @@ simulateBufferUsage actors edges initialTokens schedule =
       let production = prod (edges !! edgeIdx)
        in updateAt edgeIdx (+ production) tokens
 
-computeIOBufferSizes :: IRSystem -> [(String, Int)] -> [(String, Int)]
+computeIOBufferSizes :: IRSystem -> [(IRId, Int)] -> [(IRId, Int)]
 computeIOBufferSizes (IRSystem (inputs, outputs) _ signals _) repsWithNames =
   let -- Find all external input edges
       inputEdges =
@@ -421,7 +421,7 @@ computeIOBufferSizes (IRSystem (inputs, outputs) _ signals _) repsWithNames =
       findActorRep actorName =
         case lookup actorName repsWithNames of
           Just rep -> rep
-          Nothing -> error $ "Actor " ++ actorName ++ " not found in repetition counts"
+          Nothing -> error $ "Actor " ++ show actorName ++ " not found in repetition counts"
 
       -- Calculate input buffer size：rate × dst actor rep count
       inputBuffers =
@@ -470,7 +470,7 @@ verifySchedule actors edges initialTokens schedule _repetitionCounts =
 ----------------------------------------------------------
 
 -- | Returns schedule as actor names and buffer sizes
-computeScheduleAndBuffers :: IRSystem -> ([String], [(String, Int)], [(String, String)])
+computeScheduleAndBuffers :: IRSystem -> ([IRId], [(IRId, Int)], [(IRId, IRId)])
 computeScheduleAndBuffers irSystem =
   let (actors, edges) = convertIRSystem irSystem
    in if null edges
@@ -511,7 +511,7 @@ computeScheduleAndBuffers irSystem =
                 else
                   error "Matrix rank is not equal to number of actors minus one. Cannot compute repetition vector."
 
-getBuffers :: [Edge] -> [(String, String)]
+getBuffers :: [Edge] -> [(IRId, IRId)]
 getBuffers edges =
   concatMap
     ( \e ->
@@ -539,10 +539,10 @@ computeScheduleAndBuffersPrint irSystem =
               allBufSizes = ioBufSizes ++ internalBufSizes
            in "No internal edges found.\n\n"
                 ++ "Schedule (all actors fire once):\n"
-                ++ intercalate ", " schedNames
+                ++ intercalate ", " (map show schedNames)
                 ++ "\n\nI/O buffer sizes:"
                 ++ concatMap
-                  (\(edgeNameVal, sz) -> "\n  " ++ edgeNameVal ++ ": " ++ show sz)
+                  (\(edgeNameVal, sz) -> "\n  " ++ show edgeNameVal ++ ": " ++ show sz)
                   allBufSizes
         else
           let mat = buildTopologyMatrixEdgesRows actors edges
@@ -584,7 +584,7 @@ computeScheduleAndBuffersPrint irSystem =
 
                       repVecStr =
                         "\n\nNormalized repetition vector for ACTORS (integers):"
-                          ++ intercalate "\n" [label ++ "=" ++ show r | (label, r) <- zip (map name actors) repInt]
+                          ++ intercalate "\n" [show label ++ "=" ++ show r | (label, r) <- zip (map name actors) repInt]
 
                       repCounts = map fromIntegral repInt :: [Int]
                       repsWithNames = zip (map name actors) repCounts
@@ -593,13 +593,13 @@ computeScheduleAndBuffersPrint irSystem =
 
                       schedStr =
                         "\n\nGenerated schedule (actor firing order):\n"
-                          ++ intercalate ", " schedNames
+                          ++ intercalate ", " (map show schedNames)
 
                       initialTokensStr =
                         "\n\nInitial tokens (provided by IR):"
                           ++ concatMap
                             (\(ename, e) -> "\n " ++ ename ++ ": " ++ show (initTokens e))
-                            (zip (map edgeName edges) edges)
+                            (zip (map (show . edgeName) edges) edges)
 
                       ok = verifySchedule actors edges (map initTokens edges) schedIdxs repCounts
                       verificationSchedStr =
@@ -614,19 +614,19 @@ computeScheduleAndBuffersPrint irSystem =
                       internalBufStr =
                         "\n\nInternal buffer sizes (maximum tokens observed per edge):"
                           ++ concatMap
-                            (\(ename, sz) -> "\n  " ++ ename ++ ": " ++ show sz)
+                            (\(ename, sz) -> "\n  " ++ show ename ++ ": " ++ show sz)
                             internalBufSizes
 
                       ioBufStr =
                         "\n\nI/O buffer sizes (rate × repetition count):"
                           ++ concatMap
-                            (\(ename, sz) -> "\n  " ++ ename ++ ": " ++ show sz)
+                            (\(ename, sz) -> "\n  " ++ show ename ++ ": " ++ show sz)
                             ioBufSizes
 
                       allBufStr =
                         "\n\nAll buffer sizes (I/O + internal):"
                           ++ concatMap
-                            (\(ename, sz) -> "\n  " ++ ename ++ ": " ++ show sz)
+                            (\(ename, sz) -> "\n  " ++ show ename ++ ": " ++ show sz)
                             allBufSizes
                    in header
                         ++ nullSpaceStr

--- a/src/Utilities.hs
+++ b/src/Utilities.hs
@@ -3,6 +3,7 @@ module Utilities (compileToCore, noInlineTypecheck, scheduleAndBuffer) where
 import CoreIRToForSyDeIR (translateCoreProgram)
 import Data.Data (Data, gmapT)
 import Data.Generics (extT)
+import ForSyDeIR (IRId (..))
 import GHC
 import GHC.Driver.Main
 import GHC.Paths (libdir)
@@ -88,7 +89,7 @@ noInlineTypecheck tcg = tcg {tcg_binds = applySystemBinds (tcg_binds tcg)}
 
 -- | Utility function to obtain output of SDF Scheduler. Meant for testing to be
 -- used in a repl.
-scheduleAndBuffer :: FilePath -> IO ([String], [(String, Int)], [(String, String)])
+scheduleAndBuffer :: FilePath -> IO ([IRId], [(IRId, Int)], [(IRId, IRId)])
 scheduleAndBuffer filePath = do
   (core, dflags) <- (compileToCore filePath)
   let (forsydeIR, _lookupSignals) = translateCoreProgram dflags core

--- a/test/ForSyDeIRSpec.hs
+++ b/test/ForSyDeIRSpec.hs
@@ -10,16 +10,16 @@ import Test.Hspec
 simpleIRSystem :: IRSystem
 simpleIRSystem =
   IRSystem
-    (["input"], ["output"])
-    [ IRActor "actor_1" Actor22 "add" (["s_in", "s_2"], ["s_out", "s_1"]),
-      IRDelay "delay_1" [0] ("s_1", "s_2")
+    ([IRString "input"], [IRString "output"])
+    [ IRActor (IRString "actor_1") Actor22 (IRString "add") ([IRString "s_in", IRString "s_2"], [IRString "s_out", IRString "s_1"]),
+      IRDelay (IRString "delay_1") [0] (IRString "s_1", IRString "s_2")
     ]
-    [ IRSignal "s_in" ("input", 1) ("actor_1", 1),
-      IRSignal "s_1" ("actor_1", 1) ("delay_1", 1),
-      IRSignal "s_2" ("delay_1", 1) ("actor_1", 1),
-      IRSignal "s_out" ("actor_1", 1) ("output", 1)
+    [ IRSignal (IRString "s_in") (IRString "input", 1) (IRString "actor_1", 1),
+      IRSignal (IRString "s_1") (IRString "actor_1", 1) (IRString "delay_1", 1),
+      IRSignal (IRString "s_2") (IRString "delay_1", 1) (IRString "actor_1", 1),
+      IRSignal (IRString "s_out") (IRString "actor_1", 1) (IRString "output", 1)
     ]
-    [ IRFunction "add" Nothing
+    [ IRFunction (IRString "add") Nothing
     ]
 
 customDflags :: IO DynFlags

--- a/test/SDFScheduleSpec.hs
+++ b/test/SDFScheduleSpec.hs
@@ -11,110 +11,110 @@ import Test.Hspec
 exampleSystem1 :: IRSystem
 exampleSystem1 =
   IRSystem
-    (["input"], ["output"])
-    [ IRActor "actor_1" Actor22 "add" (["s_in", "s_2"], ["s_out", "s_1"]),
-      IRDelay "delay_1" [0] ("s_1", "s_2")
+    ([IRString "input"], [IRString "output"])
+    [ IRActor (IRString "actor_1") Actor22 (IRString "add") ([IRString "s_in", IRString "s_2"], [IRString "s_out", IRString "s_1"]),
+      IRDelay (IRString "delay_1") [0] (IRString "s_1", IRString "s_2")
     ]
-    [ IRSignal "s_in" ("input", 1) ("actor_1", 1),
-      IRSignal "s_1" ("actor_1", 1) ("delay_1", 1),
-      IRSignal "s_2" ("delay_1", 1) ("actor_1", 1),
-      IRSignal "s_out" ("actor_1", 1) ("output", 1)
+    [ IRSignal (IRString "s_in") (IRString "input", 1) (IRString "actor_1", 1),
+      IRSignal (IRString "s_1") (IRString "actor_1", 1) (IRString "delay_1", 1),
+      IRSignal (IRString "s_2") (IRString "delay_1", 1) (IRString "actor_1", 1),
+      IRSignal (IRString "s_out") (IRString "actor_1", 1) (IRString "output", 1)
     ]
-    [ IRFunction "add" Nothing
+    [ IRFunction (IRString "add") Nothing
     ]
 
 -- System with single actor and nothing else
 exampleSystem2 :: IRSystem
 exampleSystem2 =
   IRSystem
-    (["in"], ["out"])
-    [ IRActor "actor" Actor11 "add" (["s_in"], ["s_out"])
+    ([IRString "in"], [IRString "out"])
+    [ IRActor (IRString "actor") Actor11 (IRString "add") ([IRString "s_in"], [IRString "s_out"])
     ]
-    [ IRSignal "s_in" ("in", 1) ("actor", 1),
-      IRSignal "s_out" ("actor", 1) ("out", 1)
+    [ IRSignal (IRString "s_in") (IRString "in", 1) (IRString "actor", 1),
+      IRSignal (IRString "s_out") (IRString "actor", 1) (IRString "out", 1)
     ]
-    [ IRFunction "add" Nothing
+    [ IRFunction (IRString "add") Nothing
     ]
 
 -- System with two actors, one self loop
 exampleSystem3 :: IRSystem
 exampleSystem3 =
   IRSystem
-    (["input"], ["output"])
-    [ IRActor "actor_1" Actor22 "add" (["s_in", "s_2"], ["s_1", "s_3"]),
-      IRDelay "delay_1" [0] ("s_1", "s_2"),
-      IRActor "actor_2" Actor11 "add" (["s_3"], ["s_out"])
+    ([IRString "input"], [IRString "output"])
+    [ IRActor (IRString "actor_1") Actor22 (IRString "add") ([IRString "s_in", IRString "s_2"], [IRString "s_1", IRString "s_3"]),
+      IRDelay (IRString "delay_1") [0] (IRString "s_1", IRString "s_2"),
+      IRActor (IRString "actor_2") Actor11 (IRString "add") ([IRString "s_3"], [IRString "s_out"])
     ]
-    [ IRSignal "s_in" ("input", 1) ("actor_1", 1),
-      IRSignal "s_1" ("actor_1", 1) ("delay_1", 1),
-      IRSignal "s_2" ("delay_1", 1) ("actor_1", 1),
-      IRSignal "s_3" ("actor_1", 1) ("actor_2", 1),
-      IRSignal "s_out" ("actor_2", 1) ("output", 1)
+    [ IRSignal (IRString "s_in") (IRString "input", 1) (IRString "actor_1", 1),
+      IRSignal (IRString "s_1") (IRString "actor_1", 1) (IRString "delay_1", 1),
+      IRSignal (IRString "s_2") (IRString "delay_1", 1) (IRString "actor_1", 1),
+      IRSignal (IRString "s_3") (IRString "actor_1", 1) (IRString "actor_2", 1),
+      IRSignal (IRString "s_out") (IRString "actor_2", 1) (IRString "output", 1)
     ]
-    [ IRFunction "add" Nothing
+    [ IRFunction (IRString "add") Nothing
     ]
 
 -- System with multiple inputs
 exampleSystem4 :: IRSystem
 exampleSystem4 =
   IRSystem
-    (["s_ina", "s_inb"], ["s_out"])
-    [ IRActor "actor_a" Actor11 "add" (["s_ina"], ["s_1"]),
-      IRActor "actor_b" Actor11 "add" (["s_inb"], ["s_2"]),
-      IRActor "actor_c" Actor21 "add" (["s_1", "s_4"], ["s_3"]),
-      IRActor "actor_d" Actor22 "add" (["s_2", "s_3"], ["s_4_delay", "s_out"]),
-      IRDelay "delay" [0] ("s_4_delay", "s_4")
+    ([IRString "s_ina", IRString "s_inb"], [IRString "s_out"])
+    [ IRActor (IRString "actor_a") Actor11 (IRString "add") ([IRString "s_ina"], [IRString "s_1"]),
+      IRActor (IRString "actor_b") Actor11 (IRString "add") ([IRString "s_inb"], [IRString "s_2"]),
+      IRActor (IRString "actor_c") Actor21 (IRString "add") ([IRString "s_1", IRString "s_4"], [IRString "s_3"]),
+      IRActor (IRString "actor_d") Actor22 (IRString "add") ([IRString "s_2", IRString "s_3"], [IRString "s_4_delay", IRString "s_out"]),
+      IRDelay (IRString "delay") [0] (IRString "s_4_delay", IRString "s_4")
     ]
-    [ IRSignal "s_ina" ("s_ina", 1) ("actor_a", 2),
-      IRSignal "s_inb" ("s_inb", 1) ("actor_b", 1),
-      IRSignal "s_1" ("actor_a", 1) ("actor_c", 2),
-      IRSignal "s_2" ("actor_b", 2) ("actor_d", 2),
-      IRSignal "s_3" ("actor_c", 1) ("actor_d", 1),
-      IRSignal "s_4_delay" ("actor_d", 1) ("delay", 1),
-      IRSignal "s_4" ("delay", 1) ("actor_c", 1),
-      IRSignal "s_out" ("actor_d", 2) ("s_out", 1)
+    [ IRSignal (IRString "s_ina") (IRString "s_ina", 1) (IRString "actor_a", 2),
+      IRSignal (IRString "s_inb") (IRString "s_inb", 1) (IRString "actor_b", 1),
+      IRSignal (IRString "s_1") (IRString "actor_a", 1) (IRString "actor_c", 2),
+      IRSignal (IRString "s_2") (IRString "actor_b", 2) (IRString "actor_d", 2),
+      IRSignal (IRString "s_3") (IRString "actor_c", 1) (IRString "actor_d", 1),
+      IRSignal (IRString "s_4_delay") (IRString "actor_d", 1) (IRString "delay", 1),
+      IRSignal (IRString "s_4") (IRString "delay", 1) (IRString "actor_c", 1),
+      IRSignal (IRString "s_out") (IRString "actor_d", 2) (IRString "s_out", 1)
     ]
-    [ IRFunction "add" Nothing
+    [ IRFunction (IRString "add") Nothing
     ]
 
 exampleSystem5 :: IRSystem
 exampleSystem5 =
   IRSystem
-    (["s_in"], ["s_out"])
-    [ IRActor "a" Actor21 "add" (["s_in", "s3"], ["s1"]),
-      IRActor "b" Actor11 "add" (["s1"], ["s2"]),
-      IRActor "c" Actor12 "add" (["s2"], ["s3_delay", "s_out"]),
-      IRDelay "delay" [0, 0, 0, 0, 0, 0] ("s3_delay", "s3")
+    ([IRString "s_in"], [IRString "s_out"])
+    [ IRActor (IRString "a") Actor21 (IRString "add") ([IRString "s_in", IRString "s3"], [IRString "s1"]),
+      IRActor (IRString "b") Actor11 (IRString "add") ([IRString "s1"], [IRString "s2"]),
+      IRActor (IRString "c") Actor12 (IRString "add") ([IRString "s2"], [IRString "s3_delay", IRString "s_out"]),
+      IRDelay (IRString "delay") [0, 0, 0, 0, 0, 0] (IRString "s3_delay", IRString "s3")
     ]
-    [ IRSignal "s_in" ("s_in", 1) ("a", 2),
-      IRSignal "s1" ("a", 1) ("b", 2),
-      IRSignal "s2" ("b", 3) ("c", 1),
-      IRSignal "s3_delay" ("c", 2) ("delay", 2),
-      IRSignal "s3" ("delay", 3) ("a", 3),
-      IRSignal "s_out" ("c", 1) ("s_out", 1)
+    [ IRSignal (IRString "s_in") (IRString "s_in", 1) (IRString "a", 2),
+      IRSignal (IRString "s1") (IRString "a", 1) (IRString "b", 2),
+      IRSignal (IRString "s2") (IRString "b", 3) (IRString "c", 1),
+      IRSignal (IRString "s3_delay") (IRString "c", 2) (IRString "delay", 2),
+      IRSignal (IRString "s3") (IRString "delay", 3) (IRString "a", 3),
+      IRSignal (IRString "s_out") (IRString "c", 1) (IRString "s_out", 1)
     ]
-    [ IRFunction "add" Nothing
+    [ IRFunction (IRString "add") Nothing
     ]
 
 exampleSystem6 :: IRSystem
 exampleSystem6 =
   IRSystem
-    (["s_in"], ["s_out"])
-    [ IRActor "a" Actor12 "add" (["s_in", "s4"], ["s1"]),
-      IRActor "b" Actor11 "add" (["s1"], ["s2_delay"]),
-      IRActor "c" Actor11 "add" (["s3"], ["s4"]),
-      IRActor "d" Actor12 "add" (["s2"], ["s3", "s_out"]),
-      IRDelay "delay" [0, 0] ("s2_delay", "s2")
+    ([IRString "s_in"], [IRString "s_out"])
+    [ IRActor (IRString "a") Actor12 (IRString "add") ([IRString "s_in", IRString "s4"], [IRString "s1"]),
+      IRActor (IRString "b") Actor11 (IRString "add") ([IRString "s1"], [IRString "s2_delay"]),
+      IRActor (IRString "c") Actor11 (IRString "add") ([IRString "s3"], [IRString "s4"]),
+      IRActor (IRString "d") Actor12 (IRString "add") ([IRString "s2"], [IRString "s3", IRString "s_out"]),
+      IRDelay (IRString "delay") [0, 0] (IRString "s2_delay", IRString "s2")
     ]
-    [ IRSignal "s_in" ("s_in", 1) ("a", 2),
-      IRSignal "s1" ("a", 1) ("b", 4),
-      IRSignal "s2_delay" ("b", 1) ("delay", 1),
-      IRSignal "s2" ("delay", 2) ("d", 2),
-      IRSignal "s3" ("d", 4) ("c", 1),
-      IRSignal "s4" ("c", 4) ("a", 2),
-      IRSignal "s_out" ("d", 1) ("s_out", 1)
+    [ IRSignal (IRString "s_in") (IRString "s_in", 1) (IRString "a", 2),
+      IRSignal (IRString "s1") (IRString "a", 1) (IRString "b", 4),
+      IRSignal (IRString "s2_delay") (IRString "b", 1) (IRString "delay", 1),
+      IRSignal (IRString "s2") (IRString "delay", 2) (IRString "d", 2),
+      IRSignal (IRString "s3") (IRString "d", 4) (IRString "c", 1),
+      IRSignal (IRString "s4") (IRString "c", 4) (IRString "a", 2),
+      IRSignal (IRString "s_out") (IRString "d", 1) (IRString "s_out", 1)
     ]
-    [ IRFunction "add" Nothing
+    [ IRFunction (IRString "add") Nothing
     ]
 
 ------------------------------------------------------------------------------
@@ -125,36 +125,36 @@ spec = do
   describe "SDF scheduling examples" $ do
     it "exampleSystem1: System with single actor and self loop" $ do
       let (actualSchedule, actualBuffers, _) = computeScheduleAndBuffers exampleSystem1
-      let expectedSchedule = ["actor_1"]
-      let expectedBuffers = [("s_in", 1), ("s_out", 1), ("s_1_s_2", 1)]
+      let expectedSchedule = [IRString "actor_1"]
+      let expectedBuffers = [(IRString "s_in", 1), (IRString "s_out", 1), (IRString "s_1_s_2", 1)]
       (actualSchedule, actualBuffers) `shouldBe` (expectedSchedule, expectedBuffers)
 
     it "exampleSystem2: System with single actor and nothing else" $ do
       let (actualSchedule, actualBuffers, _) = computeScheduleAndBuffers exampleSystem2
-      let expectedSchedule = ["actor"]
-      let expectedBuffers = [("s_in", 1), ("s_out", 1)]
+      let expectedSchedule = [IRString "actor"]
+      let expectedBuffers = [(IRString "s_in", 1), (IRString "s_out", 1)]
       (actualSchedule, actualBuffers) `shouldBe` (expectedSchedule, expectedBuffers)
 
     it "exampleSystem3: System with two actors, one self loop" $ do
       let (actualSchedule, actualBuffers, _) = computeScheduleAndBuffers exampleSystem3
-      let expectedSchedule = ["actor_1", "actor_2"]
-      let expectedBuffers = [("s_in", 1), ("s_out", 1), ("s_3", 1), ("s_1_s_2", 1)]
+      let expectedSchedule = [IRString "actor_1", IRString "actor_2"]
+      let expectedBuffers = [(IRString "s_in", 1), (IRString "s_out", 1), (IRString "s_3", 1), (IRString "s_1_s_2", 1)]
       (actualSchedule, actualBuffers) `shouldBe` (expectedSchedule, expectedBuffers)
 
     it "exampleSystem4: System with multiple inputs" $ do
       let (actualSchedule, actualBuffers, _) = computeScheduleAndBuffers exampleSystem4
-      let expectedSchedule = ["actor_a", "actor_a", "actor_b", "actor_c", "actor_d"]
-      let expectedBuffers = [("s_ina", 4), ("s_inb", 1), ("s_out", 2), ("s_1", 2), ("s_2", 2), ("s_3", 1), ("s_4_delay_s_4", 1)]
+      let expectedSchedule = [IRString "actor_a", IRString "actor_a", IRString "actor_b", IRString "actor_c", IRString "actor_d"]
+      let expectedBuffers = [(IRString "s_ina", 4), (IRString "s_inb", 1), (IRString "s_out", 2), (IRString "s_1", 2), (IRString "s_2", 2), (IRString "s_3", 1), (IRString "s_4_delay_s_4", 1)]
       (actualSchedule, actualBuffers) `shouldBe` (expectedSchedule, expectedBuffers)
 
     it "exampleSystem5" $ do
       let (actualSchedule, actualBuffers, _) = computeScheduleAndBuffers exampleSystem5
-      let expectedSchedule = ["a", "a", "b", "c", "c", "c"]
-      let expectedBuffers = [("s_in", 4), ("s_out", 3), ("s1", 2), ("s2", 3), ("s3_delay_s3", 6)]
+      let expectedSchedule = [IRString "a", IRString "a", IRString "b", IRString "c", IRString "c", IRString "c"]
+      let expectedBuffers = [(IRString "s_in", 4), (IRString "s_out", 3), (IRString "s1", 2), (IRString "s2", 3), (IRString "s3_delay_s3", 6)]
       (actualSchedule, actualBuffers) `shouldBe` (expectedSchedule, expectedBuffers)
 
     it "exampleSystem6" $ do
       let (actualSchedule, actualBuffers, _) = computeScheduleAndBuffers exampleSystem6
-      let expectedSchedule = ["d", "c", "a", "a", "c", "a", "a", "b", "c", "a", "a", "c", "a", "a", "b"]
-      let expectedBuffers = [("s_in", 16), ("s_out", 1), ("s1", 4), ("s3", 4), ("s4", 4), ("s2_delay_s2", 2)]
+      let expectedSchedule = [IRString "d", IRString "c", IRString "a", IRString "a", IRString "c", IRString "a", IRString "a", IRString "b", IRString "c", IRString "a", IRString "a", IRString "c", IRString "a", IRString "a", IRString "b"]
+      let expectedBuffers = [(IRString "s_in", 16), (IRString "s_out", 1), (IRString "s1", 4), (IRString "s3", 4), (IRString "s4", 4), (IRString "s2_delay_s2", 2)]
       (actualSchedule, actualBuffers) `shouldBe` (expectedSchedule, expectedBuffers)


### PR DESCRIPTION
This takes a little more holistic approach. Basically the idea is that instead of passing around strings, we wrap the `Var` type from GHC instead, like:

```haskell
data IRId
  = IRVar Var
  | IRString String
  | Empty

instance Show IRId where
  show (IRVar i) = occNameString $ nameOccName $ varName i
  show (IRString s) = s
  show Empty = ""

instance Eq IRId where
  (==) (IRVar a) (IRVar b) = varUnique a == varUnique b
  (==) (IRString a) (IRString b) = a == b
  -- NOTE: This implies Empty is not equal to empty
  (==) Empty _ = False
  (==) _ Empty = False
  (==) (IRString a) b = a == show b
  (==) a (IRString b) = show a == b

prettyIRId :: IRId -> String
prettyIRId = show . show
```
Comparisons are done with the `Unique` type, which should keep the properties we want for the CoreIR to ForSyDeIR transformation, as well as being more efficient (not string comparison).

However, we define our own identifiers in e.g the scheduler, and we sometimes want a placeholder in CoreIR to ForSyDeIR transformation (which uses "" as a placeholder which is kind of horrible), which is why we also have `IRString` and `Empty`.