### PR TITLE
Add newline at end of file for Procedural IR prettyProgram

### DIFF
--- a/src/ProceduralIR.hs
+++ b/src/ProceduralIR.hs
@@ -408,4 +408,4 @@ prettyGlobal global = case global of
       (intercalate ",\n" (map prettyParam fields))
 
 prettyProgram :: Program -> String
-prettyProgram (Prog globals) = intercalate "\n\n" (map prettyGlobal globals)
+prettyProgram (Prog globals) = intercalate "\n\n" (map prettyGlobal globals) <> "\n"


### PR DESCRIPTION
Currently if I run:

```
bash-5.3$ cabal exec forsyde-devtools-exe -- --output-procedural-ir ./examples/model/SDF_example_003.hs --stdout
```

I get an output like
```
bash-5.3$ cabal exec forsyde-devtools-exe -- --output-procedural-ir ./examples/model/SDF_example_003.hs --stdout

...

GFuncDef(static, TVoid, "add", {(TPointer(TInt), "input_1"), (TPointer(TInt), "input_2"), (TPointer(TInt), "output")}, SScope({
  SArrayAssign("output_1", EInt(0), , EBinOp(+, EArrayAccess(EVar("input_1"), EInt(0)), EArrayAccess(EVar("input_2"), EInt(0)))),
  SArrayAssign("output_2", EInt(0), , EBinOp(+, EArrayAccess(EVar("input_1"), EInt(0)), EArrayAccess(EVar("input_2"), EInt(0))))
}))bash-5.3$
```

And when I dump this to a file there is no newline at the end of the file. This is not an issue for ForSyDeIR because it uses:
```hs
prettyIRSystem :: DynFlags -> IRSystem -> String
prettyIRSystem dflags (IRSystem (inputs, outputs) constructors signals functions) =
  printf
    "IRSystem(\n  {%s}, {%s},\n  {\n%s  },\n  {\n%s  },\n  {\n%s  }\n)\n"
    (intercalate ", " (map show inputs))
    (intercalate ", " (map show outputs))
    (indent 4 (intercalate ",\n" (map prettyIRConstructor constructors)))
    (indent 4 (intercalate ",\n" (map prettyIRSignal signals)))
    (indent 4 (intercalate ",\n" (map (prettyIRFunction dflags) functions)))
```
so not only does it `intercalate` the newline between different "things" inside the system, but it appends a final "\n" at the end of the `printf`.

However, in the current implementation (EDIT: for ProceduralIR) there is just a top-level string concatenation with `intercalate` in procedural IR
```hs
prettyProgram :: Program -> String
prettyProgram (Prog globals) = intercalate "\n\n" (map prettyGlobal globals)
```
which only puts the double newline *between* `Program`s and nothing at the end. So my current implementation is to do just do
```hs
prettyProgram :: Program -> String
prettyProgram (Prog globals) = intercalate "\n\n" (map prettyGlobal globals) <> "\n"
```

but it might be prudent to add a `printf` with a "\n" at the end so that both are implemented in a similar manner, but I think this is fine in the meanwhile.