### PR TITLE
Makes LSP executable work independently from dev env 

### DIFF
--- a/examples/test/simple.c
+++ b/examples/test/simple.c
@@ -23,7 +23,7 @@ int main() {
   }
   return 0;
   return;
-  for (int i = 0; i < n; ++i) {
+  for (int i = 0; i < n; i++) {
     printf("%d\n", i);
   }
   fifo &fifo = f;

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,10 @@
                       ];
 
                       postInstall = (old.postInstall or "") + ''
-                        wrapProgram $out/bin/forsyde-devtools-exe \
+                        wrapProgram $out/bin/forsyde-compiler-exe \
+                          --prefix PATH : ${dirOf "${old.passthru.env.NIX_GHC}"} \
+                          --set GHC_PACKAGE_PATH "${old.passthru.env.NIX_GHC_LIBDIR}/package.conf.d:"
+                        wrapProgram $out/bin/forsyde-lsp-exe \
                           --prefix PATH : ${dirOf "${old.passthru.env.NIX_GHC}"} \
                           --set GHC_PACKAGE_PATH "${old.passthru.env.NIX_GHC_LIBDIR}/package.conf.d:"
                       '';
@@ -78,9 +81,16 @@
           '';
         };
         packages.default = pkgs.forsyde-devtools;
-        apps.forsyde-devtools = {
-          type = "app";
-          program = "${self.packages.${system}.forsyde-devtools}/bin/forsyde-devtools-exe";
+        apps = {
+          forsyde-compiler = {
+            type = "app";
+            program = "${self.packages.${system}.default}/bin/forsyde-compiler-exe";
+          };
+          forsyde-lsp = {
+            type = "app";
+            program = "${self.packages.${system}.default}/bin/forsyde-lsp-exe";
+          };
+          default = self.apps.${system}.forsyde-compiler;
         };
       }
     );

--- a/forsyde-devtools.cabal
+++ b/forsyde-devtools.cabal
@@ -88,6 +88,7 @@ executable forsyde-lsp-exe
     ForSyDeIRToProceduralIR
     ProceduralIR
     ProceduralIRToC
+    SDFSchedule
     SKGraphSchema
     Utilities
 

--- a/forsyde-devtools.cabal
+++ b/forsyde-devtools.cabal
@@ -51,7 +51,7 @@ library
     SDFSchedule
     Utilities
 
-executable forsyde-devtools-exe
+executable forsyde-compiler-exe
   import: common-options
   hs-source-dirs: src
   main-is: Main.hs

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,6 +1,8 @@
 cradle:
   multi:
     - path: "src"
-      config: {cradle: {cabal: {component: "forsyde-devtools:forsyde-devtools-exe"}}}
+      config: {cradle: {cabal: {component: "forsyde-devtools:forsyde-compiler-exe"}}}
+    - path: "src"
+      config: {cradle: {cabal: {component: "forsyde-devtools:forsyde-lsp-exe"}}}
     - path: "test"
       config: {cradle: {cabal: {component: "forsyde-devtools:forsyde-devtools-test"}}}

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -7,7 +7,7 @@ import ForSyDeIR (prettyIRJSON, prettyIRSystem)
 import ForSyDeIRToProceduralIR (translateIRSystemToProgram)
 import Options.Applicative
 import ProceduralIR (prettyProgram)
-import ProceduralIRToC (formatWithClang, translateProgram)
+import ProceduralIRToC (translateProgram)
 import SDFSchedule (computeScheduleAndBuffers)
 import Utilities (compileToCore)
 
@@ -74,8 +74,7 @@ run (Arguments (InputFile input_file) output_file OutputC) = do
   let (schedule, buffers, delayBuffers) = computeScheduleAndBuffers forsydeIR
   let proceduralIR = translateIRSystemToProgram dflags schedule buffers delayBuffers lookupSignals forsydeIR
   let c = translateProgram proceduralIR True
-  cFormated <- formatWithClang c
-  write_output output_file OutputC cFormated
+  write_output output_file OutputC c
 run (Arguments (InputFile input_file) output_file OutputForSyDeIR) = do
   (core, dflags) <- compileToCore input_file
   let (forsydeIR, _lookupSignals) = translateCoreProgram dflags core

--- a/src/ProceduralIRToC.hs
+++ b/src/ProceduralIRToC.hs
@@ -2,11 +2,10 @@ module ProceduralIRToC where
 
 import Data.List (intercalate)
 import ProceduralIR
-import System.Process (readProcess)
 import Text.Printf (printf)
 
 indent :: String -> String
-indent = unlines . map ("  " ++) . lines
+indent = unlines . map ("    " ++) . lines
 
 stripSemicolon :: String -> String
 stripSemicolon str =
@@ -47,7 +46,7 @@ translateType currentType = case currentType of
   TFloat -> "float"
   TChar -> "char"
   TIdent s -> s
-  TPointer t -> translateType t ++ "*"
+  TPointer t -> translateType t ++ " *"
   TReference t -> translateType t ++ "&"
   TQualifiedType qualifers ty -> (intercalate " " (map prettyTypeQualifier qualifers)) ++ (translateType ty)
   TFunctionPointer returnType paramTypes ->
@@ -66,8 +65,12 @@ translateExpression (EChar c) = show c
 translateExpression (EString s) = show s
 translateExpression (EBinOp bop exprA exprB) =
   translateExpression exprA ++ " " ++ translateBinaryOperator bop ++ " " ++ translateExpression exprB
-translateExpression (EUnOp uop expr) =
-  translateUnaryOperator uop ++ translateExpression expr
+translateExpression (EUnOp unop@Increment expr) =
+  translateExpression expr ++ translateUnaryOperator unop
+translateExpression (EUnOp unop@Decrement expr) =
+  translateExpression expr ++ translateUnaryOperator unop
+translateExpression (EUnOp unop expr) =
+  translateUnaryOperator unop ++ translateExpression expr
 translateExpression (ECall name arguments) =
   name ++ "(" ++ intercalate ", " (map translateExpression arguments) ++ ")"
 translateExpression (ECallExpr calleeExpr arguments) =
@@ -88,8 +91,12 @@ translateExpression (EParen expr) =
 translateStatement :: Statement -> String
 translateStatement (SExpr expression) =
   translateExpression expression ++ ";"
+translateStatement (SVarDecl varType@(TPointer _pointerType) name) =
+  translateType varType ++ name ++ ";"
 translateStatement (SVarDecl varType name) =
   translateType varType ++ " " ++ name ++ ";"
+translateStatement (SVarDef varType@(TPointer _pointerType) name expression) =
+  translateType varType ++ name ++ " = " ++ translateExpression expression ++ ";"
 translateStatement (SVarDef varType name expression) =
   translateType varType ++ " " ++ name ++ " = " ++ translateExpression expression ++ ";"
 translateStatement (SAssign lhsExpression rhsExpression) =
@@ -146,6 +153,8 @@ translateStatement (SLabel label) =
   label ++ ":"
 
 translateParam :: (Type, String) -> String
+translateParam (paramType@(TPointer _pointerType), paramName) =
+  translateType paramType ++ paramName
 translateParam (paramType, paramName) =
   translateType paramType ++ " " ++ paramName
 
@@ -200,11 +209,7 @@ translateProgram :: Program -> Bool -> String
 translateProgram (Prog globals) includes =
   if includes
     then
-      "typedef int token;\n#include <stdio.h>\n#include \"include/common.h\"\n"
-        ++ intercalate "\n" (map translateGlobal globals)
+      "typedef int token;\n#include \"include/common.h\"\n#include <stdio.h>\n\n"
+        ++ intercalate "\n\n" (map translateGlobal globals)
     else
-      intercalate "\n" (map translateGlobal globals)
-
-formatWithClang :: String -> IO String
-formatWithClang code =
-  readProcess "clang-format" ["--style={BasedOnStyle: llvm, IndentWidth: 4}"] code
+      intercalate "\n\n" (map translateGlobal globals)

--- a/test/ProceduralIRToCSpec.hs
+++ b/test/ProceduralIRToCSpec.hs
@@ -148,8 +148,8 @@ spec :: Spec
 spec = beforeAll readExpectedCode $ do
   describe "Procedural IR To C Codegen" $ do
     it "Test hand-crafted Procedural IR" $ \simpleCString -> do
-      formatted <- formatWithClang (translateProgram exampleProceduralIR False)
-      normalize formatted `shouldBe` normalize simpleCString
+      let cString = translateProgram exampleProceduralIR False
+      normalize cString `shouldBe` normalize simpleCString
   where
     normalize = filter (not . isSpace)
     readExpectedCode = readFile "examples/test/simple.c"


### PR DESCRIPTION
- Wraps the LSP executable to include the Haskell packages required to build it, just like the compiler.
- Changes the compiler executable to `forsyde-compiler-exe`.

Relates to #277.