### PR TITLE
Argument parsing: add TARGET option for C code

### DIFF
--- a/forsyde-devtools.cabal
+++ b/forsyde-devtools.cabal
@@ -42,6 +42,7 @@ library
   import: common-options
   hs-source-dirs: src
   exposed-modules:
+    ArgumentsMain
     CoreIR
     CoreIRToForSyDeIR
     ForSyDeIR

--- a/src/ArgumentsMain.hs
+++ b/src/ArgumentsMain.hs
@@ -31,12 +31,18 @@ data OutputFormat
   | OutputForSyDeIRJSON
   | OutputProceduralIR
 
+data Target
+  = PC
+  | PICO2
+
 data Arguments = Arguments
   { -- Files
     input :: Input,
     output :: Output,
     -- Formats
-    output_format :: OutputFormat
+    output_format :: OutputFormat,
+    -- Target
+    target :: Target
   }
 
 -- Handle file input, always need to define a file
@@ -165,6 +171,28 @@ outputFormatProceduralIR =
         <> help "Output file in Procedural-IR"
     )
 
+targetName :: ReadM Target
+targetName = str >>= returnTarget
+  where
+    returnTarget s = case s of
+      "PC" -> pure (PC)
+      "PICO2" -> pure (PICO2)
+      t -> error ("Unsupported target: " ++ t)
+
+-- Parse target platform. Uses pattern matching to handle raw strings which
+-- means it is used  like "--target={target}" as opposed to having --target-PC,
+-- target-PICO2, etc
+targetTop :: Parser Target
+targetTop =
+  option
+    (targetName)
+    ( short 't'
+        <> long "target"
+        <> metavar "TARGET"
+        <> value PC
+        <> help "Target platform for C code. (PC default, PC and PICO2 supported)"
+    )
+
 -- Top level argument parsing function, takes 4 flags.
 arguments :: Parser Arguments
 arguments =
@@ -172,3 +200,4 @@ arguments =
     <$> inputFile
     <*> outputFileTop
     <*> outputFormatTop
+    <*> targetTop

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -68,29 +68,29 @@ generateDefaultFileName f OutputProceduralIR = f ++ ".pir"
 
 run :: Arguments -> IO ()
 -- "Normal run"
-run (Arguments (InputFile input_file) output_file OutputC) = do
+run (Arguments (InputFile input_file) output_file OutputC t) = do
   (core, dflags) <- compileToCore input_file
   let (forsydeIR, lookupSignals) = translateCoreProgram dflags core
   let (schedule, buffers, delayBuffers) = computeScheduleAndBuffers forsydeIR
   let proceduralIR = translateIRSystemToProgram dflags schedule buffers delayBuffers lookupSignals forsydeIR
-  let c = translateProgram proceduralIR True
+  let c = translateProgram proceduralIR t True
   write_output output_file OutputC c
-run (Arguments (InputFile input_file) output_file OutputForSyDeIR) = do
+run (Arguments (InputFile input_file) output_file OutputForSyDeIR _) = do
   (core, dflags) <- compileToCore input_file
   let (forsydeIR, _lookupSignals) = translateCoreProgram dflags core
   write_output output_file OutputForSyDeIR (prettyIRSystem dflags forsydeIR)
-run (Arguments (InputFile input_file) output_file OutputForSyDeIRJSON) = do
+run (Arguments (InputFile input_file) output_file OutputForSyDeIRJSON _) = do
   (core, dflags) <- compileToCore input_file
   let (forsydeIR, _lookupSignals) = translateCoreProgram dflags core
   let ir_json = prettyIRJSON forsydeIR
   write_output output_file OutputForSyDeIRJSON ir_json
-run (Arguments (InputFile input_file) output_file OutputProceduralIR) = do
+run (Arguments (InputFile input_file) output_file OutputProceduralIR _) = do
   (core, dflags) <- compileToCore input_file
   let (forsydeIR, lookupSignals) = translateCoreProgram dflags core
   let (schedule, buffers, delayBuffers) = computeScheduleAndBuffers forsydeIR
   let proceduralIR = translateIRSystemToProgram dflags schedule buffers delayBuffers lookupSignals forsydeIR
   write_output output_file OutputProceduralIR (prettyProgram proceduralIR)
-run (Arguments (InputFile input_file) output_file OutputCore) = do
+run (Arguments (InputFile input_file) output_file OutputCore _) = do
   (core, dflags) <- compileToCore input_file
   write_output output_file OutputCore (prettyCoreProgram dflags core)
 

--- a/src/ProceduralIRToC.hs
+++ b/src/ProceduralIRToC.hs
@@ -1,5 +1,6 @@
 module ProceduralIRToC where
 
+import ArgumentsMain (Target (PC, PICO2))
 import Data.List (intercalate)
 import ProceduralIR
 import Text.Printf (printf)
@@ -205,11 +206,17 @@ translateGlobal global = case global of
       (structId)
       (intercalate ",\n" (map translateParam fields))
 
-translateProgram :: Program -> Bool -> String
-translateProgram (Prog globals) includes =
-  if includes
-    then
-      "typedef int token;\n#include \"include/common.h\"\n#include <stdio.h>\n\n"
-        ++ intercalate "\n\n" (map translateGlobal globals)
-    else
-      intercalate "\n\n" (map translateGlobal globals)
+translateProgram :: Program -> Target -> Bool -> String
+translateProgram (Prog globals) target includes =
+  let targetText = case target of
+        PC -> "#define PLATFORM PC\n"
+        PICO2 -> "#define PLATFORM PICO2\n"
+  in let outputProgram =
+          if includes
+            then
+              targetText ++
+              "typedef int token;\n#include \"include/common.h\"\n#include <stdio.h>\n\n"
+                ++ intercalate "\n\n" (map translateGlobal globals)
+            else
+              intercalate "\n\n" (map translateGlobal globals)
+        in outputProgram ++ "\n"

--- a/test/ProceduralIRToCSpec.hs
+++ b/test/ProceduralIRToCSpec.hs
@@ -1,5 +1,6 @@
 module ProceduralIRToCSpec (spec) where
 
+import ArgumentsMain
 import Data.Char (isSpace)
 import ProceduralIR
 import ProceduralIRToC
@@ -148,7 +149,7 @@ spec :: Spec
 spec = beforeAll readExpectedCode $ do
   describe "Procedural IR To C Codegen" $ do
     it "Test hand-crafted Procedural IR" $ \simpleCString -> do
-      let cString = translateProgram exampleProceduralIR False
+      let cString = translateProgram exampleProceduralIR PC False
       normalize cString `shouldBe` normalize simpleCString
   where
     normalize = filter (not . isSpace)


### PR DESCRIPTION

## Description

Adds the argument option `TARGET` to compiler
- "t" for short option, i.e can do `forsyde-devtools-exe -t PC`
- "target" for long option, i,e can do `forsyde-devtools-ex --target PC` or `forsyde-devtools-ex --target=PC`

Have also added to help text so that it now says:

```
Available options:
  ...
  -t,--target TARGET       Target platform for C code. (PC default, PC and PICO2
                           supported)
  -h,--help                Show this help text
```

## How to run

Check that the tests pass. I added a newline at the end of the file for the `example/test/simple.c`. I also modified so that `translateProgram` now takes platform as argument, so I just inserted `PC` as platform for the test. But since the test is already running without "include" I made it so that this target is omitted when running without include, this is fine right?

Otherwise, try running

```
cabal exec forsyde-devtools-exe -- ./examples/model/SDF_example_008.hs --stdout --output-c --target=PC
```

and check that it has
```
#define PLATFORM PC
typedef int token;
#include "include/common.h"
#include <stdio.h>
```
at the top and that

```
cabal exec forsyde-devtools-exe -- ./examples/model/SDF_example_008.hs --stdout --output-c --target=PICO2
```
has 
```
#define PLATFORM PICO2
typedef int token;
#include "include/common.h"
#include <stdio.h>
```
at the top

## Other comments

I think this way of implementing target raises the following question, why is `output` not implemented in the same way? I.e:
```
--output={Core,ForSyDeIR,ForSyDeIRJSON,ProceduralIR,C}
```
instead of
```
  --output-c
  --output-core
  --output-forsyde-ir
  --output-forsyde-ir-json
  --output-procedural-ir
```
(or possibly have it the other way around, so target is also implemented like that). I currently have it so if you call with an unsupported platform it outputs the following:
```
bash-5.3$ cabal exec forsyde-devtools-exe -- ./examples/model/SDF_example_008.hs --stdout --output-c --target=PC2
Configuration is affected by the following files:
- cabal.project
forsyde-devtools-exe: Unsupported target: PC2
CallStack (from HasCallStack):
  error, called at src/ArgumentsMain.hs:180:12 in forsyde-devtools-0.0.0.1-inplace-forsyde-devtools-exe:ArgumentsMain
HasCallStack backtrace:
  collectBacktraces, called at libraries/ghc-internal/src/GHC/Internal/Exception.hs:169:13 in ghc-internal:GHC.Internal.Exception
  toExceptionWithBacktrace, called at libraries/ghc-internal/src/GHC/Internal/Exception.hs:204:5 in ghc-internal:GHC.Internal.Exception
  error, called at src/ArgumentsMain.hs:180:12 in forsyde-devtools-0.0.0.1-inplace-forsyde-devtools-exe:ArgumentsMain
```
where it says "Unsupported target: PC2" if you try to compile it for the coveted PC2 platform.