### PR TITLE
Argument parsing: add output schedule option to compiler

### DIFF
--- a/forsyde-devtools.cabal
+++ b/forsyde-devtools.cabal
@@ -42,6 +42,7 @@ library
   import: common-options
   hs-source-dirs: src
   exposed-modules:
+    ArgumentsMain
     CoreIR
     CoreIRToForSyDeIR
     ForSyDeIR

--- a/src/ArgumentsMain.hs
+++ b/src/ArgumentsMain.hs
@@ -31,12 +31,18 @@ data OutputFormat
   | OutputForSyDeIRJSON
   | OutputProceduralIR
 
+data Target
+  = PC
+  | PICO2
+
 data Arguments = Arguments
   { -- Files
     input :: Input,
     output :: Output,
     -- Formats
-    output_format :: OutputFormat
+    output_format :: OutputFormat,
+    -- Target
+    target :: Target
   }
 
 -- Handle file input, always need to define a file
@@ -165,6 +171,28 @@ outputFormatProceduralIR =
         <> help "Output file in Procedural-IR"
     )
 
+targetName :: ReadM Target
+targetName = str >>= returnTarget
+  where
+    returnTarget s = case s of
+      "PC" -> pure (PC)
+      "PICO2" -> pure (PICO2)
+      t -> error ("Unsupported target: " ++ t)
+
+-- Parse target platform. Uses pattern matching to handle raw strings which
+-- means it is used  like "--target={target}" as opposed to having --target-PC,
+-- target-PICO2, etc
+targetTop :: Parser Target
+targetTop =
+  option
+    (targetName)
+    ( short 't'
+        <> long "target"
+        <> metavar "TARGET"
+        <> value PC
+        <> help "Target platform for C code. (PC default, PC and PICO2 supported)"
+    )
+
 -- Top level argument parsing function, takes 4 flags.
 arguments :: Parser Arguments
 arguments =
@@ -172,3 +200,4 @@ arguments =
     <$> inputFile
     <*> outputFileTop
     <*> outputFormatTop
+    <*> targetTop

--- a/src/ArgumentsMain.hs
+++ b/src/ArgumentsMain.hs
@@ -30,6 +30,7 @@ data OutputFormat
   | OutputForSyDeIR
   | OutputForSyDeIRJSON
   | OutputProceduralIR
+  | OutputSchedule
 
 data Target
   = PC
@@ -128,6 +129,7 @@ outputFormatTop =
     <|> outputFormatForSyDeIR
     <|> outputFormatForSyDeIRJSON
     <|> outputFormatProceduralIR
+    <|> outputFormatSchedule
 
 -- Temporary implementation. Sets output to core as default functionality,
 outputFormatC :: Parser OutputFormat
@@ -169,6 +171,14 @@ outputFormatProceduralIR =
     OutputProceduralIR
     ( long "output-procedural-ir"
         <> help "Output file in Procedural-IR"
+    )
+
+outputFormatSchedule :: Parser OutputFormat
+outputFormatSchedule =
+  flag'
+    OutputSchedule
+    ( long "output-schedule"
+        <> help "Output the SDF schedule to file instead of code"
     )
 
 targetName :: ReadM Target

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -8,7 +8,7 @@ import ForSyDeIRToProceduralIR (translateIRSystemToProgram)
 import Options.Applicative
 import ProceduralIR (prettyProgram)
 import ProceduralIRToC (translateProgram)
-import SDFSchedule (computeScheduleAndBuffers)
+import SDFSchedule (computeScheduleAndBuffers, computeScheduleAndBuffersPrint)
 import Utilities (compileToCore)
 
 {-
@@ -59,6 +59,7 @@ generateDefaultFileName f OutputCore = f ++ ".hcr"
 generateDefaultFileName f OutputForSyDeIR = f ++ ".fir"
 generateDefaultFileName f OutputForSyDeIRJSON = f ++ ".json"
 generateDefaultFileName f OutputProceduralIR = f ++ ".pir"
+generateDefaultFileName f OutputSchedule = f ++ ".sched"
 
 -- Main function for running after arguments have been returned from main.
 -- Need to pattern match based on the arguments used. They are matched on
@@ -93,6 +94,10 @@ run (Arguments (InputFile input_file) output_file OutputProceduralIR _) = do
 run (Arguments (InputFile input_file) output_file OutputCore _) = do
   (core, dflags) <- compileToCore input_file
   write_output output_file OutputCore (prettyCoreProgram dflags core)
+run (Arguments (InputFile input_file) output_file OutputSchedule _) = do
+  (core, dflags) <- compileToCore input_file
+  let (forsydeIR, _) = translateCoreProgram dflags core
+  write_output output_file OutputSchedule (computeScheduleAndBuffersPrint forsydeIR)
 
 main :: IO ()
 main = run =<< execParser opts

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -68,29 +68,29 @@ generateDefaultFileName f OutputProceduralIR = f ++ ".pir"
 
 run :: Arguments -> IO ()
 -- "Normal run"
-run (Arguments (InputFile input_file) output_file OutputC) = do
+run (Arguments (InputFile input_file) output_file OutputC t) = do
   (core, dflags) <- compileToCore input_file
   let (forsydeIR, lookupSignals) = translateCoreProgram dflags core
   let (schedule, buffers, delayBuffers) = computeScheduleAndBuffers forsydeIR
   let proceduralIR = translateIRSystemToProgram dflags schedule buffers delayBuffers lookupSignals forsydeIR
-  let c = translateProgram proceduralIR True
+  let c = translateProgram proceduralIR t True
   write_output output_file OutputC c
-run (Arguments (InputFile input_file) output_file OutputForSyDeIR) = do
+run (Arguments (InputFile input_file) output_file OutputForSyDeIR _) = do
   (core, dflags) <- compileToCore input_file
   let (forsydeIR, _lookupSignals) = translateCoreProgram dflags core
   write_output output_file OutputForSyDeIR (prettyIRSystem dflags forsydeIR)
-run (Arguments (InputFile input_file) output_file OutputForSyDeIRJSON) = do
+run (Arguments (InputFile input_file) output_file OutputForSyDeIRJSON _) = do
   (core, dflags) <- compileToCore input_file
   let (forsydeIR, _lookupSignals) = translateCoreProgram dflags core
   let ir_json = prettyIRJSON forsydeIR
   write_output output_file OutputForSyDeIRJSON ir_json
-run (Arguments (InputFile input_file) output_file OutputProceduralIR) = do
+run (Arguments (InputFile input_file) output_file OutputProceduralIR _) = do
   (core, dflags) <- compileToCore input_file
   let (forsydeIR, lookupSignals) = translateCoreProgram dflags core
   let (schedule, buffers, delayBuffers) = computeScheduleAndBuffers forsydeIR
   let proceduralIR = translateIRSystemToProgram dflags schedule buffers delayBuffers lookupSignals forsydeIR
   write_output output_file OutputProceduralIR (prettyProgram proceduralIR)
-run (Arguments (InputFile input_file) output_file OutputCore) = do
+run (Arguments (InputFile input_file) output_file OutputCore _) = do
   (core, dflags) <- compileToCore input_file
   write_output output_file OutputCore (prettyCoreProgram dflags core)
 

--- a/src/ProceduralIRToC.hs
+++ b/src/ProceduralIRToC.hs
@@ -1,5 +1,6 @@
 module ProceduralIRToC where
 
+import ArgumentsMain (Target (PC, PICO2))
 import Data.List (intercalate)
 import ProceduralIR
 import Text.Printf (printf)
@@ -205,11 +206,17 @@ translateGlobal global = case global of
       (structId)
       (intercalate ",\n" (map translateParam fields))
 
-translateProgram :: Program -> Bool -> String
-translateProgram (Prog globals) includes =
-  if includes
-    then
-      "typedef int token;\n#include \"include/common.h\"\n#include <stdio.h>\n\n"
-        ++ intercalate "\n\n" (map translateGlobal globals)
-    else
-      intercalate "\n\n" (map translateGlobal globals)
+translateProgram :: Program -> Target -> Bool -> String
+translateProgram (Prog globals) target includes =
+  let targetText = case target of
+        PC -> "#define PLATFORM PC\n"
+        PICO2 -> "#define PLATFORM PICO2\n"
+  in let outputProgram =
+          if includes
+            then
+              targetText ++
+              "typedef int token;\n#include \"include/common.h\"\n#include <stdio.h>\n\n"
+                ++ intercalate "\n\n" (map translateGlobal globals)
+            else
+              intercalate "\n\n" (map translateGlobal globals)
+        in outputProgram ++ "\n"

--- a/src/SDFSchedule.hs
+++ b/src/SDFSchedule.hs
@@ -529,117 +529,119 @@ getBuffers edges =
 computeScheduleAndBuffersPrint :: IRSystem -> String
 computeScheduleAndBuffersPrint irSystem =
   let (actors, edges) = convertIRSystem irSystem
-   in if null edges
-        then
-          -- If there are no internal edges, fire all actor once, no buffer required
-          let schedNames = map name actors
-              repsWithNames = zip (map name actors) (replicate (length actors) 1)
-              internalBufSizes = zip (map edgeName edges) (replicate (length edges) 0)
-              ioBufSizes = computeIOBufferSizes irSystem repsWithNames
-              allBufSizes = ioBufSizes ++ internalBufSizes
-           in "No internal edges found.\n\n"
-                ++ "Schedule (all actors fire once):\n"
-                ++ intercalate ", " (map show schedNames)
-                ++ "\n\nI/O buffer sizes:"
-                ++ concatMap
-                  (\(edgeNameVal, sz) -> "\n  " ++ show edgeNameVal ++ ": " ++ show sz)
-                  allBufSizes
-        else
-          let mat = buildTopologyMatrixEdgesRows actors edges
-              matrixStr = matrixEdgesRowsToString edges actors mat
+   in let outputString =
+            if null edges
+              then
+                -- If there are no internal edges, fire all actor once, no buffer required
+                let schedNames = map name actors
+                    repsWithNames = zip (map name actors) (replicate (length actors) 1)
+                    internalBufSizes = zip (map edgeName edges) (replicate (length edges) 0)
+                    ioBufSizes = computeIOBufferSizes irSystem repsWithNames
+                    allBufSizes = ioBufSizes ++ internalBufSizes
+                 in "No internal edges found.\n\n"
+                      ++ "Schedule (all actors fire once):\n"
+                      ++ intercalate ", " (map show schedNames)
+                      ++ "\n\nI/O buffer sizes:"
+                      ++ concatMap
+                        (\(edgeNameVal, sz) -> "\n  " ++ show edgeNameVal ++ ": " ++ show sz)
+                        allBufSizes
+              else
+                let mat = buildTopologyMatrixEdgesRows actors edges
+                    matrixStr = matrixEdgesRowsToString edges actors mat
 
-              rankMat = rank mat
-              header =
-                matrixStr
-                  ++ "\n\nMatrix Rank: "
-                  ++ show rankMat
-                  ++ "\nNumber of actors: "
-                  ++ show (length actors)
-                  ++ "\nNumber of edges: "
-                  ++ show (length edges)
-           in if rankMat == length actors - 1
-                then
-                  let ns = computeNullSpace mat
-                      repVec = flatten (takeColumns 1 ns)
-                      repInt = normalizeToInteger repVec
+                    rankMat = rank mat
+                    header =
+                      matrixStr
+                        ++ "\n\nMatrix Rank: "
+                        ++ show rankMat
+                        ++ "\nNumber of actors: "
+                        ++ show (length actors)
+                        ++ "\nNumber of edges: "
+                        ++ show (length edges)
+                 in if rankMat == length actors - 1
+                      then
+                        let ns = computeNullSpace mat
+                            repVec = flatten (takeColumns 1 ns)
+                            repInt = normalizeToInteger repVec
 
-                      -- Verification: multiply the integer repetition vector back to the topology matrix
-                      repVector = fromIntegral <$> repInt :: [R]
-                      verificationResult = mat #> vector repVector
-                      isZeroVector = all (\x -> abs x < 1e-9) (LinearAlgebra.toList verificationResult)
+                            -- Verification: multiply the integer repetition vector back to the topology matrix
+                            repVector = fromIntegral <$> repInt :: [R]
+                            verificationResult = mat #> vector repVector
+                            isZeroVector = all (\x -> abs x < 1e-9) (LinearAlgebra.toList verificationResult)
 
-                      nullSpaceStr =
-                        "\n\nNull Space (fractional repetition vector for actors):\n"
-                          ++ dispToString 4 ns
+                            nullSpaceStr =
+                              "\n\nNull Space (fractional repetition vector for actors):\n"
+                                ++ dispToString 4 ns
 
-                      verificationStr =
-                        "\n\nVerification of null space vector:"
-                          ++ "\nTopology Matrix × Repetition Vector ≈ Zero Vector? "
-                          ++ show isZeroVector
-                          ++ if not isZeroVector
-                            then
-                              "\nWarning: Product is not zero!\nProduct vector:\n"
-                                ++ show verificationResult
-                            else ""
+                            verificationStr =
+                              "\n\nVerification of null space vector:"
+                                ++ "\nTopology Matrix × Repetition Vector ≈ Zero Vector? "
+                                ++ show isZeroVector
+                                ++ if not isZeroVector
+                                  then
+                                    "\nWarning: Product is not zero!\nProduct vector:\n"
+                                      ++ show verificationResult
+                                  else ""
 
-                      repVecStr =
-                        "\n\nNormalized repetition vector for ACTORS (integers):"
-                          ++ intercalate "\n" [show label ++ "=" ++ show r | (label, r) <- zip (map name actors) repInt]
+                            repVecStr =
+                              "\n\nNormalized repetition vector for ACTORS (integers):"
+                                ++ intercalate "\n" [show label ++ "=" ++ show r | (label, r) <- zip (map name actors) repInt]
 
-                      repCounts = map fromIntegral repInt :: [Int]
-                      repsWithNames = zip (map name actors) repCounts
-                      schedIdxs = greedySchedule actors edges repCounts
-                      schedNames = map (name . (actors !!)) schedIdxs
+                            repCounts = map fromIntegral repInt :: [Int]
+                            repsWithNames = zip (map name actors) repCounts
+                            schedIdxs = greedySchedule actors edges repCounts
+                            schedNames = map (name . (actors !!)) schedIdxs
 
-                      schedStr =
-                        "\n\nGenerated schedule (actor firing order):\n"
-                          ++ intercalate ", " (map show schedNames)
+                            schedStr =
+                              "\n\nGenerated schedule (actor firing order):\n"
+                                ++ intercalate ", " (map show schedNames)
 
-                      initialTokensStr =
-                        "\n\nInitial tokens (provided by IR):"
-                          ++ concatMap
-                            (\(ename, e) -> "\n " ++ ename ++ ": " ++ show (initTokens e))
-                            (zip (map (show . edgeName) edges) edges)
+                            initialTokensStr =
+                              "\n\nInitial tokens (provided by IR):"
+                                ++ concatMap
+                                  (\(ename, e) -> "\n " ++ ename ++ ": " ++ show (initTokens e))
+                                  (zip (map (show . edgeName) edges) edges)
 
-                      ok = verifySchedule actors edges (map initTokens edges) schedIdxs repCounts
-                      verificationSchedStr =
-                        "\n\nVerification of schedule with computed initial tokens: "
-                          ++ (if ok then "OK" else "FAILED")
+                            ok = verifySchedule actors edges (map initTokens edges) schedIdxs repCounts
+                            verificationSchedStr =
+                              "\n\nVerification of schedule with computed initial tokens: "
+                                ++ (if ok then "OK" else "FAILED")
 
-                      -- Simulate buffer usage for one period
-                      internalBufSizes = simulateBufferUsage actors edges (map initTokens edges) schedIdxs
-                      ioBufSizes = computeIOBufferSizes irSystem repsWithNames
-                      allBufSizes = ioBufSizes ++ internalBufSizes
+                            -- Simulate buffer usage for one period
+                            internalBufSizes = simulateBufferUsage actors edges (map initTokens edges) schedIdxs
+                            ioBufSizes = computeIOBufferSizes irSystem repsWithNames
+                            allBufSizes = ioBufSizes ++ internalBufSizes
 
-                      internalBufStr =
-                        "\n\nInternal buffer sizes (maximum tokens observed per edge):"
-                          ++ concatMap
-                            (\(ename, sz) -> "\n  " ++ show ename ++ ": " ++ show sz)
-                            internalBufSizes
+                            internalBufStr =
+                              "\n\nInternal buffer sizes (maximum tokens observed per edge):"
+                                ++ concatMap
+                                  (\(ename, sz) -> "\n  " ++ show ename ++ ": " ++ show sz)
+                                  internalBufSizes
 
-                      ioBufStr =
-                        "\n\nI/O buffer sizes (rate × repetition count):"
-                          ++ concatMap
-                            (\(ename, sz) -> "\n  " ++ show ename ++ ": " ++ show sz)
-                            ioBufSizes
+                            ioBufStr =
+                              "\n\nI/O buffer sizes (rate × repetition count):"
+                                ++ concatMap
+                                  (\(ename, sz) -> "\n  " ++ show ename ++ ": " ++ show sz)
+                                  ioBufSizes
 
-                      allBufStr =
-                        "\n\nAll buffer sizes (I/O + internal):"
-                          ++ concatMap
-                            (\(ename, sz) -> "\n  " ++ show ename ++ ": " ++ show sz)
-                            allBufSizes
-                   in header
-                        ++ nullSpaceStr
-                        ++ verificationStr
-                        ++ repVecStr
-                        ++ schedStr
-                        ++ initialTokensStr
-                        ++ verificationSchedStr
-                        ++ internalBufStr
-                        ++ ioBufStr
-                        ++ allBufStr
-                else
-                  header ++ "\n\nMatrix rank is not equal to number of actors minus one. Cannot compute repetition vector."
+                            allBufStr =
+                              "\n\nAll buffer sizes (I/O + internal):"
+                                ++ concatMap
+                                  (\(ename, sz) -> "\n  " ++ show ename ++ ": " ++ show sz)
+                                  allBufSizes
+                         in header
+                              ++ nullSpaceStr
+                              ++ verificationStr
+                              ++ repVecStr
+                              ++ schedStr
+                              ++ initialTokensStr
+                              ++ verificationSchedStr
+                              ++ internalBufStr
+                              ++ ioBufStr
+                              ++ allBufStr
+                      else
+                        header ++ "\n\nMatrix rank is not equal to number of actors minus one. Cannot compute repetition vector."
+       in outputString ++ "\n"
 
 -- Helper function to convert matrix display to string
 dispToString :: Int -> Matrix R -> String

--- a/test/ProceduralIRToCSpec.hs
+++ b/test/ProceduralIRToCSpec.hs
@@ -1,5 +1,6 @@
 module ProceduralIRToCSpec (spec) where
 
+import ArgumentsMain
 import Data.Char (isSpace)
 import ProceduralIR
 import ProceduralIRToC
@@ -148,7 +149,7 @@ spec :: Spec
 spec = beforeAll readExpectedCode $ do
   describe "Procedural IR To C Codegen" $ do
     it "Test hand-crafted Procedural IR" $ \simpleCString -> do
-      let cString = translateProgram exampleProceduralIR False
+      let cString = translateProgram exampleProceduralIR PC False
       normalize cString `shouldBe` normalize simpleCString
   where
     normalize = filter (not . isSpace)


### PR DESCRIPTION
## Description

This is based on #282 so should probably merge that one first. Adds `--output-schedule` argument option to compiler. This runs the `computeScheduleAndBuffersPrint` function from the scheduler and prints the output. If ran without the `-o` flag it will default to `main.sched` as the filename, and if ran with `--stdout` it will print the output to the terminal.

## How to run

In general just check that the tests run as intended with
```
cabal test
```

Additionally, I changed the function `computeScheduleAndBuffersPrint` so that it adds a newline at the end of the file, so make sure that if you run for instance:

```
cabal exec forsyde-devtools-exe -- ./examples/model/SDF_example_003.hs --stdout --output-schedule
```

that it actually adds a newline at the end of the file

```
bash-5.3$ cabal exec forsyde-devtools-exe -- ./examples/model/SDF_example_003.hs --stdout --output-schedule
Configuration is affected by the following files:
- cabal.project
Topology Matrix (Edges × Actors):
Edge\Actoa_a  
--------------
s_1_s_2  0.0

...

All buffer sizes (I/O + internal):
  s_in: 1
  s_out: 1
  s_1_s_2: 1
bash-5.3$ 
```