### PR TITLE
feat(vscode-ext): spawn forsyde-lsp-exe before extension starts

### DIFF
--- a/vscode-ext/.vscodeignore
+++ b/vscode-ext/.vscodeignore
@@ -13,3 +13,5 @@ client/node_modules/**
 !client/node_modules/vscode-languageserver-types/**
 !client/node_modules/{minimatch,brace-expansion,concat-map,balanced-match}/**
 !client/node_modules/{semver,lru-cache,yallist}/**
+dist/**
+esbuild.*

--- a/vscode-ext/client/src/extension.ts
+++ b/vscode-ext/client/src/extension.ts
@@ -1,3 +1,4 @@
+import { ChildProcess, spawn } from "node:child_process";
 import { connect, NetConnectOpts, Socket } from "net";
 import { ExtensionContext } from "vscode";
 import * as vscode from "vscode";
@@ -11,6 +12,7 @@ import {
 
 let client: LanguageClient;
 let socket: Socket;
+let serverProcess: ChildProcess;
 
 export async function activate(context: ExtensionContext) {
   const serverOptions: ServerOptions = createServerOptions(context);
@@ -49,6 +51,7 @@ export function deactivate(): Thenable<void> | undefined {
       socket.end(resolve);
       return;
     }
+    serverProcess?.kill("SIGKILL");
     client?.stop().then(resolve);
   });
 }
@@ -72,10 +75,23 @@ function createServerOptions(context: ExtensionContext): ServerOptions {
   } else {
     console.log("Spawning to language server as a process.");
     const lsp_executable = context.asAbsolutePath(`server/forsyde-lsp-exe`);
+    serverProcess = spawn(lsp_executable, [], {
+      detached: false,
+      stdio: "inherit"
+    });
 
-    return {
-      run: { command: lsp_executable },
-      debug: { command: lsp_executable },
+    const connectionInfo: NetConnectOpts = {
+      port: 5007,
+    };
+    console.log("Connecting to language server on port: ", connectionInfo.port);
+
+    return async () => {
+      socket = connect(connectionInfo);
+      const result: StreamInfo = {
+        writer: socket,
+        reader: socket,
+      };
+      return result;
     };
   }
 }

--- a/vscode-ext/package.json
+++ b/vscode-ext/package.json
@@ -57,6 +57,7 @@
     "@stylistic/eslint-plugin": "^2.9.0",
     "@types/mocha": "^10.0.6",
     "@types/node": "^22",
+    "esbuild": "^0.27.0",
     "eslint": "^9.13.0",
     "mocha": "^10.3.0",
     "prettier": "^3.7.1",


### PR DESCRIPTION
WARNING: forsyde-lsp-exe still have bugs where it does not terminate itself when the vscode terminated.

Tester for this commit need to put a copy for `forsyde-lsp-exe` executable binary in `vscode-ext/server/` otherwise it will not work.