### PR TITLE
add option for LSP communication over stdio

### DIFF
--- a/src/ArgumentsLSP.hs
+++ b/src/ArgumentsLSP.hs
@@ -19,14 +19,21 @@ data IP
 data Port
   = TCP String
 
+-- LSP communication method
+data ProtocolCommunication
+  = CommTcp
+  | CommStdio
+
 -- Arguments, kind of horrible names but used to not shadow usage of ip/port
 -- in main. Contains an ip address, port and file name for synthesis in the
 -- server
 data Arguments = Arguments
-  { -- Files
+  { -- LSP protocol communication
+    communication :: ProtocolCommunication,
+    -- Server connection information, if protocol communication is TCP
     hostIp :: IP,
     serverPort :: Port,
-    -- Formats
+    -- What source file to use. Runs in single shot mode if not FromClient
     input :: Input
   }
 
@@ -80,11 +87,26 @@ tcpPort =
         <> help "Host TCP Port"
     )
 
--- Top level argument parsing function. 3 mandatory arguments but
--- ip and port have default values.
+-- How to communicate with the LSP client, TCP by default
+protocolComm :: Parser ProtocolCommunication
+protocolComm =
+  flag
+    CommTcp
+    CommTcp
+    ( long "tcp"
+        <> help "Protocol communcation over TCP (default)"
+    )
+    <|> flag'
+      CommStdio
+      ( long "stdio"
+          <> help "Protocol communication over standard input/output"
+      )
+
+-- Top level argument parsing function
 arguments :: Parser Arguments
 arguments =
   Arguments
-    <$> ipAddress
+    <$> protocolComm
+    <*> ipAddress
     <*> tcpPort
     <*> inputTop

--- a/src/ForSyDeIR.hs
+++ b/src/ForSyDeIR.hs
@@ -182,6 +182,15 @@ prettyIRSystem dflags (IRSystem (inputs, outputs) constructors signals functions
     (indent 4 (intercalate ",\n" (map prettyIRSignal signals)))
     (indent 4 (intercalate ",\n" (map (prettyIRFunction dflags) functions)))
 
+instance Show IRSystem where
+  show (IRSystem (inputs, outputs) constructors signals _) =
+    printf
+      "IRSystem(\n  {%s}, {%s},\n  {\n%s  },\n  {\n%s  },\n  {}\n)\n"
+      (intercalate ", " (map prettyIRId inputs))
+      (intercalate ", " (map prettyIRId outputs))
+      (indent 4 (intercalate ",\n" (map prettyIRConstructor constructors)))
+      (indent 4 (intercalate ",\n" (map prettyIRSignal signals)))
+
 -- ForSyDe IR to JSON functions
 
 instance ToJSON ActorType where

--- a/src/LSP.hs
+++ b/src/LSP.hs
@@ -336,10 +336,7 @@ handlers =
             else pure ()
 
         -- Send the diagram if the client wants it
-        if update then LSP.sendNotification diagramAcceptMethod (setSynthesis newId) else pure ()
-        if update then LSP.sendNotification diagramAcceptMethod (updateOptions newfile newId) else pure ()
-        let graphMessage = requestBounds newfile newId forsydeIR
-        if update then LSP.sendNotification diagramAcceptMethod graphMessage else pure ()
+        _ <- if update then sendModel else pure ()
 
         -- When an element is selcted, only that one seems to be sent.
         -- Therefore, just use the first one
@@ -353,6 +350,15 @@ handlers =
         pure ()
     ]
   where
+    sendModel :: LSP.LspT Config IO ()
+    sendModel = do
+      config@Config {file = f, clientId = c, system = s} <- LSP.getConfig
+      case (f, c, s) of
+        (Just curFile, Just curId, Just curSystem) ->
+          LSP.sendNotification diagramAcceptMethod (setSynthesis curId)
+            >> LSP.sendNotification diagramAcceptMethod (updateOptions curFile curId)
+            >> LSP.sendNotification diagramAcceptMethod (requestBounds curFile curId curSystem)
+        _ -> liftIO $ stderrLogger <& ("does not have enough information to send diagram: " <> T.show config) `L.WithSeverity` L.Error
     findIR :: (a -> Maybe b) -> (a -> Bool) -> [a] -> [b]
     findIR transform match l =
       foldr

--- a/src/LSP.hs
+++ b/src/LSP.hs
@@ -80,7 +80,8 @@ forSyDeIRToGraph filename (IRSystem (inputs, outputs) actors signals _) = graph
           [KRoundedRectangle [KBackgroundColor 160 160 240] 4 4]
           [ (NodeLabelsPlacement [1, 4, 6]),
             (NodeSizeConstraints [0, 1, 2, 3]),
-            (NodeSizeMinimum [64, 64])
+            (NodeSizeMinimum [64, 64]),
+            (PortConstraints 2)
           ]
       (IRDelay name _ _) ->
         createNode'
@@ -112,8 +113,8 @@ forSyDeIRToGraph filename (IRSystem (inputs, outputs) actors signals _) = graph
         nid = "$root$N$" <> T.show name
         insignals = findInputSignals signals name
         outsignals = findOutputSignals signals name
-        inports = map (createPort nid (maybe [] (\_l -> [KText "◆" []]) l) []) insignals
-        outports = map (createPort nid [] []) outsignals
+        inports = map (createPort nid (maybe [] (\_l -> [KText "◆" []]) l) [PortSide 4]) insignals
+        outports = map (createPort nid [] [PortSide 2]) outsignals
         nl = maybe [] (\lc -> [KLabel {gid = nid <> "$L$" <> T.show name, label = T.show lc}]) l
         c = inports ++ outports ++ nl
         node =

--- a/src/LSP.hs
+++ b/src/LSP.hs
@@ -301,6 +301,12 @@ handlers =
                 }
           )
         pure (),
+      LSP.notificationHandler LSP.SMethod_WorkspaceDidChangeWatchedFiles $ \_not -> do
+        _ <- recomputeModel
+        sendModel,
+      LSP.notificationHandler LSP.SMethod_TextDocumentDidSave $ \_not -> do
+        _ <- recomputeModel
+        sendModel,
       LSP.notificationHandler diagramAcceptMethod $ \LSP.TNotificationMessage {_params = p} -> do
         config <- LSP.getConfig
         -- What file should we use?
@@ -359,6 +365,21 @@ handlers =
             >> LSP.sendNotification diagramAcceptMethod (updateOptions curFile curId)
             >> LSP.sendNotification diagramAcceptMethod (requestBounds curFile curId curSystem)
         _ -> liftIO $ stderrLogger <& ("does not have enough information to send diagram: " <> T.show config) `L.WithSeverity` L.Error
+    recomputeModel :: LSP.LspT Config IO ()
+    recomputeModel = do
+      config <- LSP.getConfig
+      out <- case config of
+        Config {file = Just newfile} ->
+          liftIO $ compileToModelMaybe newfile
+        _ -> pure Nothing
+      case out of
+        Nothing -> pure ()
+        Just _ ->
+          LSP.setConfig config {system = out}
+    compileToModelMaybe f = do
+      (core, dflags) <- compileToCore f
+      let (irsystem, _lookupSignals) = CoreIRToForSyDeIR.translateCoreProgram dflags core
+      pure $ Just irsystem
     findIR :: (a -> Maybe b) -> (a -> Bool) -> [a] -> [b]
     findIR transform match l =
       foldr

--- a/src/LSP.hs
+++ b/src/LSP.hs
@@ -235,6 +235,7 @@ data Config = Config
     clientId :: Maybe T.Text,
     system :: Maybe IRSystem
   }
+  deriving (Show)
 
 defaultConfig :: Config
 defaultConfig =

--- a/src/LSP.hs
+++ b/src/LSP.hs
@@ -228,8 +228,10 @@ diagramOpenInTextEditorMessage uri sline scol eline ecol =
       "forceOpen" .= False
     ]
 
+type Config = Maybe FilePath
+
 -- | The static notification and request handlers we support
-handlers :: Handlers (LspM (Maybe FilePath))
+handlers :: Handlers (LspM Config)
 handlers =
   mconcat
     [ notificationHandler SMethod_Initialized $ \_not -> do
@@ -401,7 +403,7 @@ handlers =
           A.String _a -> Just _a
           _ -> Nothing
 
-runServerC :: Handle -> Handle -> ServerDefinition config -> IO Int
+runServerC :: Handle -> Handle -> ServerDefinition Config -> IO Int
 runServerC =
   runServerWithHandles
     (L.cmap (fmap $ T.pack . show . pretty) (L.cmap show L.logStringStderr))

--- a/src/LSP.hs
+++ b/src/LSP.hs
@@ -28,10 +28,10 @@ import Data.Proxy
 import qualified Data.Sequence as Seq
 import qualified Data.Text as T
 import ForSyDeIR
-import Language.LSP.Logging
-import Language.LSP.Protocol.Message
-import Language.LSP.Protocol.Types
-import Language.LSP.Server
+import qualified Language.LSP.Logging as LSP
+import qualified Language.LSP.Protocol.Message as LSP
+import qualified Language.LSP.Protocol.Types as LSP
+import qualified Language.LSP.Server as LSP
 import Network.Socket
 import Options.Applicative
 import Prettyprinter
@@ -39,14 +39,14 @@ import SKGraphSchema
 import System.IO
 import Utilities
 
-diagramAcceptMethod :: SMethod (Method_CustomMethod "diagram/accept")
-diagramAcceptMethod = (SMethod_CustomMethod (Proxy @"diagram/accept"))
+diagramAcceptMethod :: LSP.SMethod (LSP.Method_CustomMethod "diagram/accept")
+diagramAcceptMethod = (LSP.SMethod_CustomMethod (Proxy @"diagram/accept"))
 
-diagramOpenInTextEditor :: SMethod (Method_CustomMethod "diagram/openInTextEditor")
-diagramOpenInTextEditor = (SMethod_CustomMethod (Proxy @"diagram/openInTextEditor"))
+diagramOpenInTextEditor :: LSP.SMethod (LSP.Method_CustomMethod "diagram/openInTextEditor")
+diagramOpenInTextEditor = (LSP.SMethod_CustomMethod (Proxy @"diagram/openInTextEditor"))
 
-setPreferencesMethod :: SMethod (Method_CustomMethod "keith/preferences/setPreferences")
-setPreferencesMethod = (SMethod_CustomMethod (Proxy @"keith/preferences/setPreferences"))
+setPreferencesMethod :: LSP.SMethod (LSP.Method_CustomMethod "keith/preferences/setPreferences")
+setPreferencesMethod = (LSP.SMethod_CustomMethod (Proxy @"keith/preferences/setPreferences"))
 
 -- | Convert ForSyDe IR into the graph representation understood by KLighD
 forSyDeIRToGraph :: FilePath -> IRSystem -> GraphElement
@@ -233,21 +233,21 @@ diagramOpenInTextEditorMessage uri sline scol eline ecol =
 type Config = Maybe FilePath
 
 -- | The static notification and request handlers we support
-handlers :: Handlers (LspM Config)
+handlers :: LSP.Handlers (LSP.LspM Config)
 handlers =
   mconcat
-    [ notificationHandler SMethod_Initialized $ \_not -> do
+    [ LSP.notificationHandler LSP.SMethod_Initialized $ \_not -> do
         pure (),
-      notificationHandler setPreferencesMethod $ \_not -> do
+      LSP.notificationHandler setPreferencesMethod $ \_not -> do
         pure (),
-      notificationHandler SMethod_WorkspaceDidChangeConfiguration $ \_not -> do
+      LSP.notificationHandler LSP.SMethod_WorkspaceDidChangeConfiguration $ \_not -> do
         pure (),
-      requestHandler SMethod_Initialize $ \_req _resp -> do
+      LSP.requestHandler LSP.SMethod_Initialize $ \_req _resp -> do
         _resp
           ( Right $
-              InitializeResult
+              LSP.InitializeResult
                 { _capabilities =
-                    ServerCapabilities
+                    LSP.ServerCapabilities
                       { _positionEncoding = Nothing,
                         _textDocumentSync = Nothing,
                         _notebookDocumentSync = Nothing,
@@ -288,12 +288,12 @@ handlers =
                 }
           )
         pure (),
-      notificationHandler diagramAcceptMethod $ \TNotificationMessage {_params = p} -> do
+      LSP.notificationHandler diagramAcceptMethod $ \LSP.TNotificationMessage {_params = p} -> do
         -- In the case where the client does not provide a sourceUri, use the
         -- old one. This is the case for e.g. the refreshDiagram action
-        oldFile <- getConfig
+        oldFile <- LSP.getConfig
         let file = maybe (maybe "" id oldFile) id (getFilePathFromClient p)
-        _ <- setConfig (Just file)
+        _ <- LSP.setConfig (Just file)
 
         -- What clientId should we use?
         let clientId = maybe ("sprotty" :: T.Text) id (getClientId p)
@@ -319,17 +319,17 @@ handlers =
             else pure ()
 
         -- Send the diagram if the client wants it
-        if update then sendNotification diagramAcceptMethod (setSynthesis clientId) else pure ()
-        if update then sendNotification diagramAcceptMethod (updateOptions file clientId) else pure ()
+        if update then LSP.sendNotification diagramAcceptMethod (setSynthesis clientId) else pure ()
+        if update then LSP.sendNotification diagramAcceptMethod (updateOptions file clientId) else pure ()
         let graphMessage = requestBounds file clientId forsydeIR
-        if update then sendNotification diagramAcceptMethod graphMessage else pure ()
+        if update then LSP.sendNotification diagramAcceptMethod graphMessage else pure ()
 
         -- When an element is selcted, only that one seems to be sent.
         -- Therefore, just use the first one
         _ <- case spans of
           sspan : _ ->
             let (fname, sl, sc, el, ec) = sspan
-             in sendNotification diagramOpenInTextEditor $
+             in LSP.sendNotification diagramOpenInTextEditor $
                   diagramOpenInTextEditorMessage fname sl sc el ec
           _ -> pure ()
 
@@ -408,7 +408,7 @@ handlers =
           A.String _a -> Just _a
           _ -> Nothing
 
-logToText :: LspServerLog -> T.Text
+logToText :: LSP.LspServerLog -> T.Text
 logToText = T.show . pretty
 
 formatOut :: L.WithSeverity T.Text -> String
@@ -418,15 +418,15 @@ formatOut (L.WithSeverity m s) =
 stderrLogger :: L.LogAction IO (L.WithSeverity T.Text)
 stderrLogger = L.cmap formatOut L.logStringStderr
 
-clientLogger :: L.LogAction (LspM Config) (L.WithSeverity T.Text)
-clientLogger = defaultClientLogger
+clientLogger :: L.LogAction (LSP.LspM Config) (L.WithSeverity T.Text)
+clientLogger = LSP.defaultClientLogger
 
-dualLogger :: L.LogAction (LspM Config) (L.WithSeverity T.Text)
+dualLogger :: L.LogAction (LSP.LspM Config) (L.WithSeverity T.Text)
 dualLogger = clientLogger <> L.hoistLogAction liftIO stderrLogger
 
-runServerC :: Handle -> Handle -> ServerDefinition Config -> IO Int
+runServerC :: Handle -> Handle -> LSP.ServerDefinition Config -> IO Int
 runServerC =
-  runServerWithHandles
+  LSP.runServerWithHandles
     (L.cmap (fmap logToText) stderrLogger)
     (L.cmap (fmap logToText) dualLogger)
 
@@ -467,15 +467,15 @@ run (Arguments comm (Host ip) (TCP p) i_f) =
       pure ()
   where
     serverDef =
-      ServerDefinition
+      LSP.ServerDefinition
         { parseConfig = const $ const $ Right Nothing,
           onConfigChange = const $ pure (),
           defaultConfig = Nothing,
           configSection = "demo",
           doInitialize = \env _req -> pure $ Right env,
           staticHandlers = \_caps -> handlers,
-          interpretHandler = \env -> Iso (runLspT env) liftIO,
-          options = defaultOptions
+          interpretHandler = \env -> LSP.Iso (LSP.runLspT env) liftIO,
+          options = LSP.defaultOptions
         }
 
 -- | Listen on host and port, as well as accept and fork off connections

--- a/src/LSP.hs
+++ b/src/LSP.hs
@@ -8,6 +8,7 @@
 module Main (main) where
 
 import ArgumentsLSP
+import Colog.Core ((<&))
 import qualified Colog.Core as L
 import Control.Concurrent (forkFinally)
 import qualified Control.Exception as E
@@ -16,7 +17,7 @@ import Control.Monad.IO.Class
 import qualified CoreIRToForSyDeIR
 import Data.Aeson ((.=))
 import qualified Data.Aeson as A
-import Data.Aeson.Encode.Pretty as AP
+import qualified Data.Aeson.Encode.Pretty as AP
 import Data.Aeson.KeyMap ((!?))
 import qualified Data.ByteString.Lazy.Char8 as BSL8
 import qualified Data.Foldable as F
@@ -27,6 +28,7 @@ import Data.Proxy
 import qualified Data.Sequence as Seq
 import qualified Data.Text as T
 import ForSyDeIR
+import Language.LSP.Logging
 import Language.LSP.Protocol.Message
 import Language.LSP.Protocol.Types
 import Language.LSP.Server
@@ -311,7 +313,10 @@ handlers =
         let s = map findSignalSpan (map IRString sel) <*> [sigs] & mconcat
         let a = map findProcessSpan (map IRString sel) <*> [procs] & mconcat
         let spans = s ++ a
-        _ <- if length spans > 0 then liftIO $ hPutStrLn stderr $ show spans else pure ()
+        _ <-
+          if length spans > 0
+            then liftIO $ stderrLogger <& ("Selected: " <> T.show spans) `L.WithSeverity` L.Info
+            else pure ()
 
         -- Send the diagram if the client wants it
         if update then sendNotification diagramAcceptMethod (setSynthesis clientId) else pure ()
@@ -403,11 +408,27 @@ handlers =
           A.String _a -> Just _a
           _ -> Nothing
 
+logToText :: LspServerLog -> T.Text
+logToText = T.show . pretty
+
+formatOut :: L.WithSeverity T.Text -> String
+formatOut (L.WithSeverity m s) =
+  show s <> ": " <> T.unpack m
+
+stderrLogger :: L.LogAction IO (L.WithSeverity T.Text)
+stderrLogger = L.cmap formatOut L.logStringStderr
+
+clientLogger :: L.LogAction (LspM Config) (L.WithSeverity T.Text)
+clientLogger = defaultClientLogger
+
+dualLogger :: L.LogAction (LspM Config) (L.WithSeverity T.Text)
+dualLogger = clientLogger <> L.hoistLogAction liftIO stderrLogger
+
 runServerC :: Handle -> Handle -> ServerDefinition Config -> IO Int
 runServerC =
   runServerWithHandles
-    (L.cmap (fmap $ T.pack . show . pretty) (L.cmap show L.logStringStderr))
-    (L.cmap (fmap $ T.pack . show . pretty) (L.cmap show L.logStringStderr))
+    (L.cmap (fmap logToText) stderrLogger)
+    (L.cmap (fmap logToText) dualLogger)
 
 -- | Process arguments for the LSP and run it
 main :: IO ()

--- a/src/LSP.hs
+++ b/src/LSP.hs
@@ -50,7 +50,7 @@ setPreferencesMethod = (LSP.SMethod_CustomMethod (Proxy @"keith/preferences/setP
 
 -- | Convert ForSyDe IR into the graph representation understood by KLighD
 forSyDeIRToGraph :: FilePath -> IRSystem -> GraphElement
-forSyDeIRToGraph file (IRSystem (inputs, outputs) actors signals _) = graph
+forSyDeIRToGraph filename (IRSystem (inputs, outputs) actors signals _) = graph
   where
     -- \| Create a port with a label for signal rate
     createPortWithRate parent rends props (n, r) =
@@ -150,7 +150,7 @@ forSyDeIRToGraph file (IRSystem (inputs, outputs) actors signals _) = graph
     edges = map createEdge signals
     graph =
       KGraph
-        { gid = T.pack ("file://" ++ file),
+        { gid = T.pack ("file://" ++ filename),
           child =
             KNode
               { gid = "$root",
@@ -163,9 +163,9 @@ forSyDeIRToGraph file (IRSystem (inputs, outputs) actors signals _) = graph
 
 -- | Send our supported syntheses to the LSP client (KLighD-VSCode)
 setSynthesis :: T.Text -> A.Value
-setSynthesis clientId =
+setSynthesis _clientId =
   A.object
-    [ "clientId" .= clientId,
+    [ "clientId" .= _clientId,
       "action"
         .= A.object
           [ "kind" .= ("setSyntheses" :: T.Text),
@@ -181,9 +181,9 @@ setSynthesis clientId =
 
 -- | Send the supported options for the file
 updateOptions :: FilePath -> T.Text -> A.Value
-updateOptions f clientId =
+updateOptions f _clientId =
   A.object
-    [ "clientId" .= clientId,
+    [ "clientId" .= _clientId,
       "action"
         .= A.object
           [ "kind" .= ("updateOptions" :: T.Text),
@@ -196,9 +196,9 @@ updateOptions f clientId =
 
 -- | Send the graph for layout and display to the LSP client (KLighD-VSCode)
 requestBounds :: FilePath -> T.Text -> IRSystem -> A.Value
-requestBounds f clientId ir =
+requestBounds f _clientId ir =
   A.object
-    [ "clientId" .= clientId,
+    [ "clientId" .= _clientId,
       "action"
         .= A.object
           [ "kind" .= ("requestBounds" :: T.Text),
@@ -230,7 +230,19 @@ diagramOpenInTextEditorMessage uri sline scol eline ecol =
       "forceOpen" .= False
     ]
 
-type Config = Maybe FilePath
+data Config = Config
+  { file :: Maybe FilePath,
+    clientId :: Maybe T.Text,
+    system :: Maybe IRSystem
+  }
+
+defaultConfig :: Config
+defaultConfig =
+  Config
+    { file = Nothing,
+      clientId = Nothing,
+      system = Nothing
+    }
 
 -- | The static notification and request handlers we support
 handlers :: LSP.Handlers (LSP.LspM Config)
@@ -289,24 +301,28 @@ handlers =
           )
         pure (),
       LSP.notificationHandler diagramAcceptMethod $ \LSP.TNotificationMessage {_params = p} -> do
-        -- In the case where the client does not provide a sourceUri, use the
-        -- old one. This is the case for e.g. the refreshDiagram action
-        oldFile <- LSP.getConfig
-        let file = maybe (maybe "" id oldFile) id (getFilePathFromClient p)
-        _ <- LSP.setConfig (Just file)
-
+        config <- LSP.getConfig
+        -- What file should we use?
+        let newfile = maybe (maybe "" id $ file config) id (getFilePathFromClient p)
         -- What clientId should we use?
-        let clientId = maybe ("sprotty" :: T.Text) id (getClientId p)
+        let newId = maybe (maybe ("sprotty" :: T.Text) id $ clientId config) id (getClientId p)
+        -- TODO: maybe only recompute on TextDocumentDidSave
+        (core, dflags) <- liftIO $ compileToCore newfile
+        let (forsydeIR, _lookupSignals) = CoreIRToForSyDeIR.translateCoreProgram dflags core
+        -- Update config with new data
+        _ <-
+          LSP.setConfig
+            config
+              { file = Just newfile,
+                clientId = Just newId,
+                system = Just forsydeIR
+              }
 
         -- Decode elementSelected
         let sel = getSelected p & map (T.split (\_c -> _c == '$')) & map last & map T.unpack
 
         -- Does the client want a diagram?
         let update = shouldUpdate p
-
-        -- TODO: maybe only recompute on TextDocumentDidSave
-        (core, dflags) <- liftIO $ compileToCore file
-        let (forsydeIR, _lookupSignals) = CoreIRToForSyDeIR.translateCoreProgram dflags core
 
         -- Get location information on selected object
         let IRSystem _ procs sigs _ = forsydeIR
@@ -319,9 +335,9 @@ handlers =
             else pure ()
 
         -- Send the diagram if the client wants it
-        if update then LSP.sendNotification diagramAcceptMethod (setSynthesis clientId) else pure ()
-        if update then LSP.sendNotification diagramAcceptMethod (updateOptions file clientId) else pure ()
-        let graphMessage = requestBounds file clientId forsydeIR
+        if update then LSP.sendNotification diagramAcceptMethod (setSynthesis newId) else pure ()
+        if update then LSP.sendNotification diagramAcceptMethod (updateOptions newfile newId) else pure ()
+        let graphMessage = requestBounds newfile newId forsydeIR
         if update then LSP.sendNotification diagramAcceptMethod graphMessage else pure ()
 
         -- When an element is selcted, only that one seems to be sent.
@@ -468,9 +484,9 @@ run (Arguments comm (Host ip) (TCP p) i_f) =
   where
     serverDef =
       LSP.ServerDefinition
-        { parseConfig = const $ const $ Right Nothing,
+        { parseConfig = const $ const $ Right defaultConfig,
           onConfigChange = const $ pure (),
-          defaultConfig = Nothing,
+          defaultConfig = defaultConfig,
           configSection = "demo",
           doInitialize = \env _req -> pure $ Right env,
           staticHandlers = \_caps -> handlers,

--- a/src/LSP.hs
+++ b/src/LSP.hs
@@ -309,7 +309,7 @@ handlers =
         let s = map findSignalSpan (map IRString sel) <*> [sigs] & mconcat
         let a = map findProcessSpan (map IRString sel) <*> [procs] & mconcat
         let spans = s ++ a
-        _ <- if length spans > 0 then liftIO $ putStrLn $ show spans else pure ()
+        _ <- if length spans > 0 then liftIO $ hPutStrLn stderr $ show spans else pure ()
 
         -- Send the diagram if the client wants it
         if update then sendNotification diagramAcceptMethod (setSynthesis clientId) else pure ()
@@ -421,9 +421,9 @@ main = run =<< execParser opts
 
 -- | Start the LSP
 run :: Arguments -> IO ()
-run (Arguments (Host ip) (TCP p) i_f) =
-  case i_f of
-    FromClient ->
+run (Arguments comm (Host ip) (TCP p) i_f) =
+  case (i_f, comm) of
+    (FromClient, CommTcp) ->
       runTCPServer (Just ip) p lsp
       where
         lsp s = do
@@ -431,23 +431,29 @@ run (Arguments (Host ip) (TCP p) i_f) =
           -- server returns IO Int, wrapper with "pure ()" so that expression
           -- returns IO ()
           _ <-
-            runServerC handle handle $
-              ServerDefinition
-                { parseConfig = const $ const $ Right Nothing,
-                  onConfigChange = const $ pure (),
-                  defaultConfig = Nothing,
-                  configSection = "demo",
-                  doInitialize = \env _req -> pure $ Right env,
-                  staticHandlers = \_caps -> handlers,
-                  interpretHandler = \env -> Iso (runLspT env) liftIO,
-                  options = defaultOptions
-                }
+            runServerC handle handle serverDef
           pure ()
-    InputFile f -> do
+    (FromClient, CommStdio) -> do
+      _ <- runServerC stdin stdout serverDef
+      pure ()
+    (InputFile f, _) -> do
       (core, dflags) <- liftIO $ compileToCore f
       let (forsydeIR, _lookupSignals) = CoreIRToForSyDeIR.translateCoreProgram dflags core
       let graphMessage = requestBounds f "sprotty" forsydeIR
       BSL8.putStrLn $ AP.encodePretty graphMessage
+      pure ()
+  where
+    serverDef =
+      ServerDefinition
+        { parseConfig = const $ const $ Right Nothing,
+          onConfigChange = const $ pure (),
+          defaultConfig = Nothing,
+          configSection = "demo",
+          doInitialize = \env _req -> pure $ Right env,
+          staticHandlers = \_caps -> handlers,
+          interpretHandler = \env -> Iso (runLspT env) liftIO,
+          options = defaultOptions
+        }
 
 -- | Listen on host and port, as well as accept and fork off connections
 runTCPServer :: Maybe HostName -> ServiceName -> (Socket -> IO a1) -> IO a2

--- a/src/SKGraphSchema.hs
+++ b/src/SKGraphSchema.hs
@@ -52,6 +52,8 @@ data KProperty
   | JunctionPoints [Int]
   | LayerConstraint Int
   | PortBorderOffset Float
+  | PortSide Int
+  | PortConstraints Int
 
 data KPlacementData
   = KTopPosition Float Float -- absolute (Float), relative (Float)
@@ -321,3 +323,5 @@ instance A.ToJSON GraphElement where
         JunctionPoints l -> ("org.eclipse.elk.junctionPoints", A.toJSON $ Seq.fromList l)
         LayerConstraint v -> ("org.eclipse.elk.layered.layering.layerConstraint", A.toJSON v)
         PortBorderOffset v -> ("org.eclipse.elk.port.borderOffset", A.toJSON v)
+        PortSide v -> ("org.eclipse.elk.port.side", A.toJSON v)
+        PortConstraints v -> ("org.eclipse.elk.portConstraints", A.toJSON v)

--- a/vscode-ext/client/src/extension.ts
+++ b/vscode-ext/client/src/extension.ts
@@ -25,7 +25,7 @@ export async function activate(context: ExtensionContext) {
 
   // Create the language client and start the client.
   client = new LanguageClient(
-    "Language Server Example",
+    "ForSyDe DevTools LSP",
     serverOptions,
     clientOptions,
     true,
@@ -74,8 +74,8 @@ function createServerOptions(context: ExtensionContext): ServerOptions {
     const lsp_executable = context.asAbsolutePath(`server/forsyde-lsp-exe`);
 
     return {
-      run: { command: lsp_executable },
-      debug: { command: lsp_executable },
+      run: { command: lsp_executable, args: ["--stdio"] },
+      debug: { command: lsp_executable, args: ["--stdio"] },
     };
   }
 }


### PR DESCRIPTION
It turns out that it's much easier to launch the LSP server from VSCode correctly this way after all.

To try this out, check out the branch and:
```sh
nix build
mkdir -p vscode-ext/server
cp -f result/bin/{*,.[!.]*} vscode-ext/server
cd vscode-ext/client
npm install
cd ..
npm install
npm run compile
code --extensionDevelopmentPath=$PWD ..
```

This PR also addresses #291, makes input ports be on the west and output ports be on the east (#299) .