### PR TITLE
Core IR to Procedural IR

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -165,7 +165,7 @@ The following is a set of programmer restrictions which limit what the compiler 
 - The input program should be a correct Haskell/ForSyDe program. ForSyDe DevTools currently does not have any input validity checking mechanisms.
 - "where" scopes are not allowed to be nested except for the initial module scope.
 - "if" expressions are not allowed inside "system"
-- Net lists can only be defined using the identifier "system"
+- Netlists can only be defined using the identifier "system"
 - Type signatures should be written for all defined functions.
 - Current implementation support only "system" with one or two outputs.
 

--- a/examples/model/SDF_example_001.hs
+++ b/examples/model/SDF_example_001.hs
@@ -2,7 +2,7 @@ module SDF_example_001 where
 
 import ForSyDe.Shallow
 
--- Net list
+-- Netlist
 system :: Signal Int -> (Signal Int, Signal Int)
 system s_in = (s_out_1, s_out_2)
   where

--- a/examples/model/SDF_example_003.hs
+++ b/examples/model/SDF_example_003.hs
@@ -19,9 +19,3 @@ d_1 s_1 = delaySDF [0] s_1
 -- Function definitions
 add :: [Int] -> [Int] -> ([Int], [Int])
 add [x] [y] = ([x + y], [x + y])
-
--- add_1 [x] = [x + 1]
--- add_2 [x, y] = [x + y]
--- add_3 [x] [y] = [x + y]
--- add_4 [x, y] [z] = ([x + y + z], [x + y, x + y + z])
--- add_5 [x] [y] [z] = ([x + y + z], [x + y, x + y + z])

--- a/examples/model/SDF_example_003.hs
+++ b/examples/model/SDF_example_003.hs
@@ -2,7 +2,7 @@ module SDF_example_003 where
 
 import ForSyDe.Shallow
 
--- Net list
+-- Netlist
 system :: Signal Int -> Signal Int
 system s_in = s_out
   where

--- a/examples/model/SDF_example_004.hs
+++ b/examples/model/SDF_example_004.hs
@@ -2,7 +2,7 @@ module SDF_example_004 where
 
 import ForSyDe.Shallow
 
--- Net list
+-- Netlist
 system :: Signal Int -> Signal Int -> (Signal Int, Signal Int)
 system s_in_1 s_in_2 = (s_out_2, s_out_1)
   where

--- a/examples/model/SDF_example_005.hs
+++ b/examples/model/SDF_example_005.hs
@@ -2,7 +2,7 @@ module SDF_example_005 where
 
 import ForSyDe.Shallow
 
--- Net list
+-- Netlist
 system :: Signal Int -> (Signal Int, Signal Int)
 system s_in = (s_out_1, s_out_2)
   where

--- a/examples/model/SDF_example_009.hs
+++ b/examples/model/SDF_example_009.hs
@@ -2,7 +2,7 @@ module SDF_example_009 where
 
 import ForSyDe.Shallow
 
--- Net list
+-- Netlist
 system :: Signal Int -> (Signal Int, Signal Int, Signal Int)
 system s_in = (s_out_1, s_out_2, s_out_3)
   where

--- a/examples/model/SDF_example_010.hs
+++ b/examples/model/SDF_example_010.hs
@@ -2,7 +2,7 @@ module SDF_example_010 where
 
 import ForSyDe.Shallow
 
--- Net list
+-- Netlist
 system :: Signal Int -> Signal Int -> (Signal Int, Signal Int, Signal Int, Signal Int)
 system s_in_1 s_in_2 = (s_out_1, s_out_2, s_out_3, s_out_4)
   where

--- a/examples/model/SDF_example_011.hs
+++ b/examples/model/SDF_example_011.hs
@@ -1,0 +1,17 @@
+module SDF_example_011 where
+
+import ForSyDe.Shallow
+
+-- Net list
+system :: Signal Int -> Signal Int
+system s_in = s_out
+  where
+    s_out = a_a s_in
+
+-- Process specifications
+a_a :: Signal Int -> Signal Int
+a_a s = actor11SDF 1 1 add s
+
+-- Function definitions
+add :: [Int] -> [Int]
+add [x] = [x + 1]

--- a/examples/model/SDF_example_011.hs
+++ b/examples/model/SDF_example_011.hs
@@ -2,7 +2,7 @@ module SDF_example_011 where
 
 import ForSyDe.Shallow
 
--- Net list
+-- Netlist
 system :: Signal Int -> Signal Int
 system s_in = s_out
   where

--- a/examples/model/SDF_example_012.hs
+++ b/examples/model/SDF_example_012.hs
@@ -2,7 +2,7 @@ module SDF_example_012 where
 
 import ForSyDe.Shallow
 
--- Net list
+-- Netlist
 system :: Signal Int -> Signal Int
 system s_in = s_out
   where

--- a/examples/model/SDF_example_012.hs
+++ b/examples/model/SDF_example_012.hs
@@ -1,0 +1,17 @@
+module SDF_example_012 where
+
+import ForSyDe.Shallow
+
+-- Net list
+system :: Signal Int -> Signal Int
+system s_in = s_out
+  where
+    s_out = a_a s_in
+
+-- Process specifications
+a_a :: Signal Int -> Signal Int
+a_a s = actor11SDF 2 1 add s
+
+-- Function definitions
+add :: [Int] -> [Int]
+add [x, y] = [x + y]

--- a/examples/model/SDF_example_013.hs
+++ b/examples/model/SDF_example_013.hs
@@ -1,0 +1,17 @@
+module SDF_example_013 where
+
+import ForSyDe.Shallow
+
+-- Net list
+system :: Signal Int -> Signal Int
+system s_in = s_out
+  where
+    s_out = a_a s_in
+
+-- Process specifications
+a_a :: Signal Int -> Signal Int
+a_a s = actor11SDF 1 2 add s
+
+-- Function definitions
+add :: [Int] -> [Int]
+add [x] = [x + 1, x + 2]

--- a/examples/model/SDF_example_013.hs
+++ b/examples/model/SDF_example_013.hs
@@ -2,7 +2,7 @@ module SDF_example_013 where
 
 import ForSyDe.Shallow
 
--- Net list
+-- Netlist
 system :: Signal Int -> Signal Int
 system s_in = s_out
   where

--- a/examples/model/SDF_example_014.hs
+++ b/examples/model/SDF_example_014.hs
@@ -2,7 +2,7 @@ module SDF_example_014 where
 
 import ForSyDe.Shallow
 
--- Net list
+-- Netlist
 system :: Signal Int -> Signal Int
 system s_in = s_out
   where

--- a/examples/model/SDF_example_014.hs
+++ b/examples/model/SDF_example_014.hs
@@ -1,0 +1,17 @@
+module SDF_example_014 where
+
+import ForSyDe.Shallow
+
+-- Net list
+system :: Signal Int -> Signal Int
+system s_in = s_out
+  where
+    s_out = a_a s_in
+
+-- Process specifications
+a_a :: Signal Int -> Signal Int
+a_a s = actor11SDF 2 2 add s
+
+-- Function definitions
+add :: [Int] -> [Int]
+add [x, y] = [x + x, y + y]

--- a/examples/model/SDF_example_015.hs
+++ b/examples/model/SDF_example_015.hs
@@ -1,0 +1,17 @@
+module SDF_example_015 where
+
+import ForSyDe.Shallow
+
+-- Net list
+system :: Signal Int -> Signal Int -> Signal Int
+system s_in_1 s_in_2 = s_out
+  where
+    s_out = a_a s_in_1 s_in_2
+
+-- Process specifications
+a_a :: Signal Int -> Signal Int -> Signal Int
+a_a s_1 s_2 = actor21SDF (1, 1) 1 add s_1 s_2
+
+-- Function definitions
+add :: [Int] -> [Int] -> [Int]
+add [x] [y] = [x + y]

--- a/examples/model/SDF_example_015.hs
+++ b/examples/model/SDF_example_015.hs
@@ -2,7 +2,7 @@ module SDF_example_015 where
 
 import ForSyDe.Shallow
 
--- Net list
+-- Netlist
 system :: Signal Int -> Signal Int -> Signal Int
 system s_in_1 s_in_2 = s_out
   where

--- a/examples/model/SDF_example_016.hs
+++ b/examples/model/SDF_example_016.hs
@@ -2,7 +2,7 @@ module SDF_example_016 where
 
 import ForSyDe.Shallow
 
--- Net list
+-- Netlist
 system :: Signal Int -> Signal Int -> Signal Int
 system s_in_1 s_in_2 = s_out
   where

--- a/examples/model/SDF_example_016.hs
+++ b/examples/model/SDF_example_016.hs
@@ -1,0 +1,17 @@
+module SDF_example_016 where
+
+import ForSyDe.Shallow
+
+-- Net list
+system :: Signal Int -> Signal Int -> Signal Int
+system s_in_1 s_in_2 = s_out
+  where
+    s_out = a_a s_in_1 s_in_2
+
+-- Process specifications
+a_a :: Signal Int -> Signal Int -> Signal Int
+a_a s_1 s_2 = actor21SDF (2, 2) 1 add s_1 s_2
+
+-- Function definitions
+add :: [Int] -> [Int] -> [Int]
+add [x, y] [z, w] = [x + z, y + w]

--- a/examples/model/SDF_example_017.hs
+++ b/examples/model/SDF_example_017.hs
@@ -1,0 +1,24 @@
+module SDF_example_017 where
+
+import ForSyDe.Shallow
+
+-- Netlist
+system :: Signal Int -> Signal Int -> Signal Int
+system s_in_1 s_in_2 = s_out
+  where
+    s_1 = a_a s_in_1 s_in_2
+    s_out = a_b s_1
+
+-- Process specifications
+a_a :: Signal Int -> Signal Int -> Signal Int
+a_a s_1 s_2 = actor21SDF (1, 1) 1 multiply s_1 s_2
+
+a_b :: Signal Int -> Signal Int
+a_b s = actor11SDF 1 1 divide s
+
+-- Function definitions
+multiply :: [Int] -> [Int] -> [Int]
+multiply [x] [y] = [x * y]
+
+divide :: [Int] -> [Int]
+divide [x] = [x `div` 2]

--- a/examples/model/SDF_example_018.hs
+++ b/examples/model/SDF_example_018.hs
@@ -1,0 +1,25 @@
+module SDF_example_018 where
+
+import ForSyDe.Shallow
+
+-- Net list
+system :: Signal Int -> Signal Int
+system s_in = s_out
+  where
+    (s_out, first, second) = a_a s_in first_delayed second_delayed
+    first_delayed = d_1 first
+    second_delayed = d_2 second
+
+-- Process specifications
+a_a :: Signal Int -> Signal Int -> Signal Int -> (Signal Int, Signal Int, Signal Int)
+a_a s_1 s_2 s_3 = actor33SDF (1, 1, 1) (1, 1, 1) fib s_1 s_2 s_3
+
+d_1 :: Signal Int -> Signal Int
+d_1 s = delaySDF [0] s
+
+d_2 :: Signal Int -> Signal Int
+d_2 s = delaySDF [1] s
+
+-- Function definitions
+fib :: [Int] -> [Int] -> [Int] -> ([Int], [Int], [Int])
+fib [index] [first] [second] = ([index + first + second], [second], [index + first + second])

--- a/examples/model/SDF_example_018.hs
+++ b/examples/model/SDF_example_018.hs
@@ -2,7 +2,7 @@ module SDF_example_018 where
 
 import ForSyDe.Shallow
 
--- Net list
+-- Netlist
 system :: Signal Int -> Signal Int
 system s_in = s_out
   where

--- a/examples/model/SDF_example_019.hs
+++ b/examples/model/SDF_example_019.hs
@@ -1,0 +1,24 @@
+module SDF_example_019 where
+
+import ForSyDe.Shallow
+
+-- Netlist
+system :: Signal Int -> Signal Int -> Signal Int
+system s_in_1 s_in_2 = s_out
+  where
+    s_1 = a_a s_in_1 s_in_2
+    s_out = a_b s_1
+
+-- Process specifications
+a_a :: Signal Int -> Signal Int -> Signal Int
+a_a s_1 s_2 = actor21SDF (1, 1) 1 multiply s_1 s_2
+
+a_b :: Signal Int -> Signal Int
+a_b s = actor11SDF 1 1 negating s
+
+-- Function definitions
+multiply :: [Int] -> [Int] -> [Int]
+multiply [x] [y] = [(x + y) * 4]
+
+negating :: [Int] -> [Int]
+negating [x] = [-x]

--- a/forsyde-devtools.cabal
+++ b/forsyde-devtools.cabal
@@ -45,6 +45,7 @@ library
     ArgumentsMain
     CoreIR
     CoreIRToForSyDeIR
+    CoreIRToProceduralIR
     ForSyDeIR
     ForSyDeIRToProceduralIR
     ProceduralIR
@@ -65,6 +66,7 @@ executable forsyde-compiler-exe
     ArgumentsMain
     CoreIR
     CoreIRToForSyDeIR
+    CoreIRToProceduralIR
     ForSyDeIR
     ForSyDeIRToProceduralIR
     ProceduralIR

--- a/src/ArgumentsMain.hs
+++ b/src/ArgumentsMain.hs
@@ -144,11 +144,10 @@ outputFormatTop =
     <|> outputFormatProceduralIR
     <|> outputFormatSchedule
 
--- Temporary implementation. Sets output to core as default functionality,
 outputFormatC :: Parser OutputFormat
 outputFormatC =
   flag
-    OutputCore
+    OutputC
     OutputC
     ( long "output-c"
         <> help "Output file in C"

--- a/src/CoreIR.hs
+++ b/src/CoreIR.hs
@@ -2,16 +2,22 @@ module CoreIR where
 
 import Data.List (intercalate)
 import GHC
+import GHC.Builtin.Uniques (knownUniqueName)
 import GHC.Core
 import GHC.Driver.Ppr
-import GHC.Plugins (Literal, Var (varName), litValue, occName, occNameString)
+import GHC.Plugins (Literal, Var (varName), litValue, nameStableString, occName, occNameString, varUnique)
 import Text.Printf (printf)
 
 indent :: String -> String
 indent = unlines . map ("  " ++) . lines
 
 varToString :: Var -> String
-varToString var = occNameString $ occName $ varName var
+varToString var =
+  let stringName = occNameString $ occName $ varName var
+      maybeUniqueName = knownUniqueName $ varUnique var
+   in case maybeUniqueName of
+        Just uniqueName -> stringName ++ nameStableString uniqueName
+        Nothing -> stringName
 
 literalToInt :: Literal -> Int
 literalToInt literal = fromIntegral $ litValue literal
@@ -29,13 +35,13 @@ prettyCoreProgram dflags = intercalate "\n" . map (prettyCoreBind dflags)
 
 prettyCoreExpr :: DynFlags -> CoreExpr -> String
 prettyCoreExpr dflags expr = case expr of
-  Var i -> printf "Var(%s)" (varToString i)
+  Var i -> printf "Var(%s)" (showPpr dflags i)
   Lit l -> printf "Lit(%s)" (showPpr dflags l)
   App e a -> printf "App(%s *\n%s)" (prettyCoreExpr dflags e) (prettyCoreExpr dflags a)
-  Lam b e -> printf "Lam(%s ->\n%s)" (varToString b) (prettyCoreExpr dflags e)
+  Lam b e -> printf "Lam(%s ->\n%s)" (showPpr dflags b) (prettyCoreExpr dflags e)
   Type t -> printf "Type(%s)" (showPpr dflags t)
   Let bind e -> printf "Let(\n%s in\n%s)" (indent (prettyCoreBind dflags bind)) (indent (prettyCoreExpr dflags e))
-  Case e b _ alts -> printf "Case(%s of %s {\n%s})" (prettyCoreExpr dflags e) (showPpr dflags b) (indent (prettyCoreAltList dflags alts))
+  Case e _ t alts -> printf "Case(%s of %s {\n%s})" (prettyCoreExpr dflags e) (showPpr dflags t) (indent (prettyCoreAltList dflags alts))
   Cast e co -> printf "Cast(%s by %s)" (prettyCoreExpr dflags e) (showPpr dflags co)
   Tick t e -> printf "Tick(%s: %s)" (showPpr dflags t) (prettyCoreExpr dflags e)
   Coercion co -> printf "Coercion(%s)" (showPpr dflags co)

--- a/src/CoreIRToForSyDeIR.hs
+++ b/src/CoreIRToForSyDeIR.hs
@@ -15,8 +15,8 @@ data TranslationContext = TranslationContext
     constructors :: [(IRId, IRConstructor)], -- Associated list of pcIds and IRConstructors
     signals :: [(IRId, IRSignal)], -- Associated list of signalIds and IRSignals
     functions :: [(IRId, IRFunction)], -- Associated list of functionIds and IRFunctions
-    systemInputs :: [IRId], -- List of global inputs to net list
-    systemOutputs :: [IRId], -- List of global outputs to net list
+    systemInputs :: [IRId], -- List of global inputs to netlist
+    systemOutputs :: [IRId], -- List of global outputs to netlist
     nameCounter :: Int, -- Counter used for naming signals
     pcRates :: [(IRId, ([Int], [Int]))], -- Associated list of pcIds and input and ouput rates
     binders :: [(IRId, Binder)] -- Associated list of binderIds and Binders
@@ -70,8 +70,8 @@ translateCoreBind context (NonRec b e) = case show (IRVar b) of
 -- output, thus unsure what the expected outcome should be.
 translateCoreBind _ (Rec _) = error "translateCoreBind - `Rec` used in top level of Core output"
 
--- | Translates the `CoreExpr` which is associated with the system net list.
--- Identifies system inputs, builds the net list through a `TranslationContext`,
+-- | Translates the `CoreExpr` which is associated with the system netlist.
+-- Identifies system inputs, builds the netlist through a `TranslationContext`,
 -- and identifies system outputs.
 translateSystem :: TranslationContext -> CoreExpr -> TranslationContext
 translateSystem initialContext expr = case expr of
@@ -91,11 +91,11 @@ translateSystem initialContext expr = case expr of
      in context2
   _ -> translateSystemOutputs initialContext expr
 
--- | Identifies the system outputs of the net list and does the final clean-up
+-- | Identifies the system outputs of the netlist and does the final clean-up
 -- of the `TranslationContext` by updating constructors and signals.
 --
 -- NOTE: This function needs to be updated with new pattern matches for
--- translation to support net lists with additional system ouputs.
+-- translation to support netlists with additional system ouputs.
 translateSystemOutputs :: TranslationContext -> CoreExpr -> TranslationContext
 translateSystemOutputs initialContext expr = case expr of
   -- System has 1 output

--- a/src/CoreIRToProceduralIR.hs
+++ b/src/CoreIRToProceduralIR.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE DataKinds #-}
+
+module CoreIRToProceduralIR where
+
+import CoreIR (literalToInt, prettyCoreExpr, varToString)
+import Data.Maybe (listToMaybe, mapMaybe)
+import ForSyDeIR
+import GHC hiding (targetId)
+import GHC.Core
+import ProceduralIR
+
+data TranslationContext = TranslationContext
+  { flags :: DynFlags,
+    inputSignalIds :: [String],
+    outputSignalIds :: [String]
+  }
+
+initialTranslationContext :: DynFlags -> TranslationContext
+initialTranslationContext dflags =
+  TranslationContext
+    { flags = dflags,
+      inputSignalIds = [],
+      outputSignalIds = []
+    }
+
+translateIRFunction :: IRFunction -> DynFlags -> [IRConstructor] -> (Maybe Global, Maybe Global)
+translateIRFunction function dflags constructors =
+  let context = initialTranslationContext dflags
+   in case function of
+        IRFunction functionId Nothing ->
+          let actor = case (findActorFromFunctionId functionId constructors) of
+                Nothing -> error ("translateIRFunction - no actor associated to " ++ show functionId)
+                Just actor -> actor
+              (functionGlobal, _) = getFunctionDeclaration context functionId actor
+           in (functionGlobal, Nothing)
+        IRFunction functionId (Just functionExpr) ->
+          let actor = case (findActorFromFunctionId functionId constructors) of
+                Nothing -> error ("translateIRFunction - no actor associated to " ++ show functionId)
+                Just actor -> actor
+              (functionGlobal, context1) = getFunctionDeclaration context functionId actor
+              context2 = translateFunctionExpr context1 functionId functionExpr
+           in (functionGlobal, Nothing) -- Placeholder for actual return value
+
+-- (b, Lam _ (Lam _ e))
+--   | b == IRString "add" ->
+--       let functionScopeStmt = translateCoreExprToStatement context e
+--           initFunctionGlobal = GFuncDeclare (Just Static) TVoid (show binder) [(TPointer TInt, "input_1"), (TPointer TInt, "input_2"), (TPointer TInt, "output")]
+--           functionGlobal = GFuncDef (Just Static) TVoid (show binder) [(TPointer TInt, "input_1"), (TPointer TInt, "input_2"), (TPointer TInt, "output")] functionScopeStmt
+--        in (initFunctionGlobal, functionGlobal)
+
+-- IRActor IRId ActorType IRId ([IRId], [IRId])
+getFunctionDeclaration :: TranslationContext -> IRId -> IRConstructor -> (Maybe Global, TranslationContext)
+getFunctionDeclaration context functionId (IRActor _ _ _ (inputSignals, outputSignals)) =
+  let inputParams = map (\(idx, _) -> (TPointer (TIdent "token"), "input_" ++ show idx)) (zip [1 ..] inputSignals)
+      outputParams = map (\(idx, _) -> (TPointer (TIdent "token"), "output_" ++ show idx)) (zip [1 ..] outputSignals)
+      allParams = inputParams ++ outputParams
+      functionGlobal = GFuncDeclare (Just Static) TVoid (show functionId) allParams
+      inputSignalIds = map snd inputParams
+      outputSignalIds = map snd outputParams
+      context1 = context {inputSignalIds = inputSignalIds, outputSignalIds = outputSignalIds}
+   in (Just functionGlobal, context1)
+getFunctionDeclaration context _functionId (IRDelay _ _ _) = (Nothing, context)
+
+findActorFromFunctionId :: IRId -> [IRConstructor] -> Maybe IRConstructor
+findActorFromFunctionId targetFunctionId constructors =
+  let checkIRConstructor :: IRConstructor -> Maybe IRConstructor
+      checkIRConstructor actor@(IRActor _ _ functionId _)
+        | functionId == targetFunctionId = Just actor
+        | otherwise = Nothing
+      checkIRConstructor _ = Nothing
+   in listToMaybe (mapMaybe checkIRConstructor constructors)
+
+translateFunctionExpr :: TranslationContext -> IRId -> CoreExpr -> TranslationContext
+translateFunctionExpr context functionId coreExpr = context
+
+--     = Var	  Id
+--   | Lit   Literal
+--   | App   (Expr b) (Arg b)
+--   | Lam   b (Expr b)
+--   | Let   (Bind b) (Expr b)
+--   | Case  (Expr b) b Type [Alt b]
+--   | Cast  (Expr b) Coercion
+--   | Tick  (Tickish Id) (Expr b)
+--   | Type  Type
+--   | Coercion Coercion
+
+-- type Arg b = Expr b
+-- type Alt b = (AltCon, [b], Expr b)
+
+-- data AltCon = DataAlt DataCon | LitAlt  Literal | DEFAULT
+
+-- data Bind b = NonRec b (Expr b) | Rec [(b, (Expr b))]

--- a/src/CoreIRToProceduralIR.hs
+++ b/src/CoreIRToProceduralIR.hs
@@ -6,7 +6,6 @@
 module CoreIRToProceduralIR where
 
 import CoreIR (literalToInt, prettyCoreAlt, varToString)
-import Data.Functor.Classes (eq1)
 import Data.List (elemIndex)
 import Data.Maybe (listToMaybe, mapMaybe)
 import ForSyDeIR
@@ -15,7 +14,7 @@ import GHC.Core
 import GHC.Driver.Ppr (showPpr)
 import GHC.Plugins (Var)
 import ProceduralIR
-import Utilities (Stack, emptyStack, pop, push)
+import Utilities (Stack, emptyStack, pop, push, stackToList)
 
 data TranslationContext = TranslationContext
   { flags :: DynFlags,
@@ -48,19 +47,6 @@ data FunctionContent
   | FMultiply
   | FDiv
   | FNegate
-
-instance Show FunctionContent where
-  show :: FunctionContent -> String
-  show (FVar v) = varToString v
-  show (FInt i) = show i
-  show FColon = ":"
-  show FTuple = "(,)"
-  show FList = "[]"
-  show FPlus = "+"
-  show FMinus = "-"
-  show FMultiply = "*"
-  show FDiv = "/"
-  show FNegate = "-"
 
 translateIRFunction :: IRFunction -> DynFlags -> [IRConstructor] -> (Global, Maybe Global)
 translateIRFunction function dflags constructors =
@@ -97,13 +83,13 @@ getParameterList context (IRDelay _ _ _) = ([], context)
 getFunctionDeclaration :: [(ProceduralIR.Type, String)] -> IRId -> Global
 getFunctionDeclaration parameterList functionId =
   let functionDeclareGlobal = GFuncDeclare (Just Static) TVoid (show functionId) parameterList
-   in (functionDeclareGlobal)
+   in functionDeclareGlobal
 
 getFunctionDefinition :: TranslationContext -> [(ProceduralIR.Type, String)] -> IRId -> Global
 getFunctionDefinition context parametersList functionId =
   let stmtScope = scope context
       functionDefinitionGlobal = GFuncDef (Just Static) TVoid (show functionId) parametersList stmtScope
-   in (functionDefinitionGlobal)
+   in functionDefinitionGlobal
 
 findActorFromFunctionId :: IRId -> [IRConstructor] -> Maybe IRConstructor
 findActorFromFunctionId targetFunctionId constructors =
@@ -148,35 +134,29 @@ translateFunctionExpr context inputIndex inputCounter expr = case expr of
 
 translateFunctionContent :: TranslationContext -> [FunctionContent] -> Statement
 translateFunctionContent context contentList =
-  let finalExprsStack = aux (emptyStack) contentList
-      stmtList = stackToScope (outputSignalIds context) [] finalExprsStack
+  let finalExprsStack = foldl' functionContentToStack emptyStack contentList
+      stmtList = foldl' stackToScope [] (zip (outputSignalIds context) (stackToList finalExprsStack))
    in SScope stmtList
   where
-    stackToScope :: [String] -> [Statement] -> Stack [Expression] -> [Statement]
-    stackToScope outputSignalList acc exprsStack = case (pop exprsStack) of
-      Nothing -> acc
-      Just (exprList, exprsStack1) ->
-        let (outputSignal, outputSignalTail) = case outputSignalList of
-              [] -> error "translateFunctionContent - insufficient output signals for expressions"
-              (output : outputTail) -> (output, outputTail)
-            outputStmts = map (\(idx, expr) -> SArrayAssign outputSignal (EInt idx) Nothing expr) (zip [0 ..] exprList)
-         in stackToScope outputSignalTail (acc ++ outputStmts) exprsStack1
-    aux :: (Stack [Expression]) -> [FunctionContent] -> (Stack [Expression])
-    aux exprsStack currentContentList = case currentContentList of
-      [] -> exprsStack
-      FList : contentTail ->
+    stackToScope :: [Statement] -> (String, [Expression]) -> [Statement]
+    stackToScope acc (outputSignal, exprList) =
+      let outputStmts = map (\(idx, expr) -> SArrayAssign outputSignal (EInt idx) Nothing expr) (zip [0 ..] exprList)
+       in (acc ++ outputStmts)
+    functionContentToStack :: (Stack [Expression]) -> FunctionContent -> (Stack [Expression])
+    functionContentToStack exprsStack content = case content of
+      FList ->
         let newExprList = []
             exprsStack1 = push newExprList exprsStack
-         in aux exprsStack1 contentTail
-      (FInt i) : contentTail ->
+         in exprsStack1
+      (FInt i) ->
         let (exprList, exprsStack1) = case (pop exprsStack) of
               Nothing -> error "translateFunctionContent - empty expression stack when expecting expression list"
               Just (elist, stack1) -> (elist, stack1)
             expr = EInt i
             newExprList = expr : exprList
             exprsStack2 = push newExprList exprsStack1
-         in aux exprsStack2 contentTail
-      (FVar varId) : contentTail ->
+         in exprsStack2
+      (FVar varId) ->
         let (exprList, exprsStack1) = case (pop exprsStack) of
               Nothing -> error "translateFunctionContent - empty expression stack when expecting expression list"
               Just (elist, stack1) -> (elist, stack1)
@@ -185,8 +165,8 @@ translateFunctionContent context contentList =
               Nothing -> error ("translateFunctionContent - variable not found: " ++ varToString varId)
             newExprList = variableExpr : exprList
             exprsStack2 = push newExprList exprsStack1
-         in aux exprsStack2 contentTail
-      FPlus : contentTail ->
+         in exprsStack2
+      FPlus ->
         let (exprList, exprsStack1) = case (pop exprsStack) of
               Nothing -> error "translateFunctionContent - empty expression stack when expecting expression list"
               Just (elist, stack1) -> (elist, stack1)
@@ -199,8 +179,8 @@ translateFunctionContent context contentList =
             newExpr = EBinOp Plus expr1 expr2
             newExprList = newExpr : exprTail
             exprsStack2 = push newExprList exprsStack1
-         in aux exprsStack2 contentTail
-      FMinus : contentTail ->
+         in exprsStack2
+      FMinus ->
         let (exprList, exprsStack1) = case (pop exprsStack) of
               Nothing -> error "translateFunctionContent - empty expression stack when expecting expression list"
               Just (elist, stack1) -> (elist, stack1)
@@ -213,8 +193,8 @@ translateFunctionContent context contentList =
             newExpr = EBinOp Minus expr1 expr2
             newExprList = newExpr : exprTail
             exprsStack2 = push newExprList exprsStack1
-         in aux exprsStack2 contentTail
-      FMultiply : contentTail ->
+         in exprsStack2
+      FMultiply ->
         let (exprList, exprsStack1) = case (pop exprsStack) of
               Nothing -> error "translateFunctionContent - empty expression stack when expecting expression list"
               Just (elist, stack1) -> (elist, stack1)
@@ -227,8 +207,8 @@ translateFunctionContent context contentList =
             newExpr = EBinOp Multiply expr1 expr2
             newExprList = newExpr : exprTail
             exprsStack2 = push newExprList exprsStack1
-         in aux exprsStack2 contentTail
-      FDiv : contentTail ->
+         in exprsStack2
+      FDiv ->
         let (exprList, exprsStack1) = case (pop exprsStack) of
               Nothing -> error "translateFunctionContent - empty expression stack when expecting expression list"
               Just (elist, stack1) -> (elist, stack1)
@@ -241,8 +221,8 @@ translateFunctionContent context contentList =
             newExpr = EBinOp Divide expr1 expr2
             newExprList = newExpr : exprTail
             exprsStack2 = push newExprList exprsStack1
-         in aux exprsStack2 contentTail
-      FNegate : contentTail ->
+         in exprsStack2
+      FNegate ->
         let (exprList, exprsStack1) = case (pop exprsStack) of
               Nothing -> error "translateFunctionContent - empty expression stack when expecting expression list"
               Just (elist, stack1) -> (elist, stack1)
@@ -252,9 +232,9 @@ translateFunctionContent context contentList =
             newExpr = EParen (EUnOp Negate expr1)
             newExprList = newExpr : exprTail
             exprsStack2 = push newExprList exprsStack1
-         in aux exprsStack2 contentTail
-      FColon : contentTail -> aux exprsStack contentTail
-      FTuple : contentTail -> aux exprsStack contentTail
+         in exprsStack2
+      FColon -> exprsStack
+      FTuple -> exprsStack
 
 translateOutputExprToFunctionContentList :: TranslationContext -> CoreExpr -> [FunctionContent] -> [FunctionContent]
 translateOutputExprToFunctionContentList context expr acc = case expr of

--- a/src/CoreIRToProceduralIR.hs
+++ b/src/CoreIRToProceduralIR.hs
@@ -1,18 +1,29 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module CoreIRToProceduralIR where
 
-import CoreIR (literalToInt, prettyCoreExpr, varToString)
+import CoreIR (literalToInt, prettyCoreAlt, varToString)
+import Data.Functor.Classes (eq1)
+import Data.List (elemIndex)
 import Data.Maybe (listToMaybe, mapMaybe)
 import ForSyDeIR
 import GHC hiding (targetId)
 import GHC.Core
+import GHC.Driver.Ppr (showPpr)
+import GHC.Plugins (Var)
 import ProceduralIR
+import Utilities (Stack, emptyStack, pop, push)
 
 data TranslationContext = TranslationContext
   { flags :: DynFlags,
     inputSignalIds :: [String],
-    outputSignalIds :: [String]
+    outputSignalIds :: [String],
+    functionInputs :: [IRId],
+    functionVariables :: [(IRId, Expression)],
+    scope :: Statement
   }
 
 initialTranslationContext :: DynFlags -> TranslationContext
@@ -20,46 +31,79 @@ initialTranslationContext dflags =
   TranslationContext
     { flags = dflags,
       inputSignalIds = [],
-      outputSignalIds = []
+      outputSignalIds = [],
+      functionInputs = [],
+      functionVariables = [],
+      scope = SScope []
     }
 
-translateIRFunction :: IRFunction -> DynFlags -> [IRConstructor] -> (Maybe Global, Maybe Global)
+data FunctionContent
+  = FVar Var
+  | FInt Int
+  | FColon
+  | FTuple
+  | FList
+  | FPlus
+  | FMinus
+  | FMultiply
+  | FDiv
+  | FNegate
+
+instance Show FunctionContent where
+  show :: FunctionContent -> String
+  show (FVar v) = varToString v
+  show (FInt i) = show i
+  show FColon = ":"
+  show FTuple = "(,)"
+  show FList = "[]"
+  show FPlus = "+"
+  show FMinus = "-"
+  show FMultiply = "*"
+  show FDiv = "/"
+  show FNegate = "-"
+
+translateIRFunction :: IRFunction -> DynFlags -> [IRConstructor] -> (Global, Maybe Global)
 translateIRFunction function dflags constructors =
   let context = initialTranslationContext dflags
    in case function of
         IRFunction functionId Nothing ->
           let actor = case (findActorFromFunctionId functionId constructors) of
                 Nothing -> error ("translateIRFunction - no actor associated to " ++ show functionId)
-                Just actor -> actor
-              (functionGlobal, _) = getFunctionDeclaration context functionId actor
-           in (functionGlobal, Nothing)
+                Just a -> a
+              (parameterList, _context1) = getParameterList context actor
+              (functionDeclarationGlobal) = getFunctionDeclaration parameterList functionId
+           in (functionDeclarationGlobal, Nothing)
         IRFunction functionId (Just functionExpr) ->
           let actor = case (findActorFromFunctionId functionId constructors) of
                 Nothing -> error ("translateIRFunction - no actor associated to " ++ show functionId)
-                Just actor -> actor
-              (functionGlobal, context1) = getFunctionDeclaration context functionId actor
-              context2 = translateFunctionExpr context1 functionId functionExpr
-           in (functionGlobal, Nothing) -- Placeholder for actual return value
+                Just a -> a
+              (parameterList, context1) = getParameterList context actor
+              functionDeclarationGlobal = getFunctionDeclaration parameterList functionId
+              context2 = translateFunctionExpr context1 0 0 functionExpr
+              functionDefinitionGlobal = getFunctionDefinition context2 parameterList functionId
+           in (functionDeclarationGlobal, Just functionDefinitionGlobal)
 
--- (b, Lam _ (Lam _ e))
---   | b == IRString "add" ->
---       let functionScopeStmt = translateCoreExprToStatement context e
---           initFunctionGlobal = GFuncDeclare (Just Static) TVoid (show binder) [(TPointer TInt, "input_1"), (TPointer TInt, "input_2"), (TPointer TInt, "output")]
---           functionGlobal = GFuncDef (Just Static) TVoid (show binder) [(TPointer TInt, "input_1"), (TPointer TInt, "input_2"), (TPointer TInt, "output")] functionScopeStmt
---        in (initFunctionGlobal, functionGlobal)
+getParameterList :: TranslationContext -> IRConstructor -> ([(ProceduralIR.Type, String)], TranslationContext)
+getParameterList context (IRActor _ _ _ (inputSignals, outputSignals)) =
+  let inputParameters = map (\(idx, _) -> (TPointer (TIdent "token"), "input_" ++ show idx)) (zip [1 :: Int ..] inputSignals)
+      outputParameters = map (\(idx, _) -> (TPointer (TIdent "token"), "output_" ++ show idx)) (zip [1 :: Int ..] outputSignals)
+      parametersList = inputParameters ++ outputParameters
+      inputSignalList = map snd inputParameters
+      outputSignalList = map snd outputParameters
+      context1 = context {inputSignalIds = inputSignalList, outputSignalIds = outputSignalList}
+   in (parametersList, context1)
+getParameterList context (IRDelay _ _ _) = ([], context)
 
--- IRActor IRId ActorType IRId ([IRId], [IRId])
-getFunctionDeclaration :: TranslationContext -> IRId -> IRConstructor -> (Maybe Global, TranslationContext)
-getFunctionDeclaration context functionId (IRActor _ _ _ (inputSignals, outputSignals)) =
-  let inputParams = map (\(idx, _) -> (TPointer (TIdent "token"), "input_" ++ show idx)) (zip [1 ..] inputSignals)
-      outputParams = map (\(idx, _) -> (TPointer (TIdent "token"), "output_" ++ show idx)) (zip [1 ..] outputSignals)
-      allParams = inputParams ++ outputParams
-      functionGlobal = GFuncDeclare (Just Static) TVoid (show functionId) allParams
-      inputSignalIds = map snd inputParams
-      outputSignalIds = map snd outputParams
-      context1 = context {inputSignalIds = inputSignalIds, outputSignalIds = outputSignalIds}
-   in (Just functionGlobal, context1)
-getFunctionDeclaration context _functionId (IRDelay _ _ _) = (Nothing, context)
+getFunctionDeclaration :: [(ProceduralIR.Type, String)] -> IRId -> Global
+getFunctionDeclaration parameterList functionId =
+  let functionDeclareGlobal = GFuncDeclare (Just Static) TVoid (show functionId) parameterList
+   in (functionDeclareGlobal)
+
+getFunctionDefinition :: TranslationContext -> [(ProceduralIR.Type, String)] -> IRId -> Global
+getFunctionDefinition context parametersList functionId =
+  let stmtScope = scope context
+      functionDefinitionGlobal = GFuncDef (Just Static) TVoid (show functionId) parametersList stmtScope
+   in (functionDefinitionGlobal)
 
 findActorFromFunctionId :: IRId -> [IRConstructor] -> Maybe IRConstructor
 findActorFromFunctionId targetFunctionId constructors =
@@ -70,23 +114,184 @@ findActorFromFunctionId targetFunctionId constructors =
       checkIRConstructor _ = Nothing
    in listToMaybe (mapMaybe checkIRConstructor constructors)
 
-translateFunctionExpr :: TranslationContext -> IRId -> CoreExpr -> TranslationContext
-translateFunctionExpr context functionId coreExpr = context
+translateFunctionExpr :: TranslationContext -> Int -> Int -> CoreExpr -> TranslationContext
+translateFunctionExpr context inputIndex inputCounter expr = case expr of
+  -- Function with 4 inputs
+  Lam b1 (Lam b2 (Lam b3 (Lam b4 e))) ->
+    let context1 = context {functionInputs = [(IRVar b1), (IRVar b2), (IRVar b3), (IRVar b4)]}
+     in translateFunctionExpr context1 inputIndex inputCounter e
+  -- Function with 3 inputs
+  Lam b1 (Lam b2 (Lam b3 e)) ->
+    let context1 = context {functionInputs = [(IRVar b1), (IRVar b2), (IRVar b3)]}
+     in translateFunctionExpr context1 inputIndex inputCounter e
+  -- Function with 2 inputs
+  Lam b1 (Lam b2 e) ->
+    let context1 = context {functionInputs = [(IRVar b1), (IRVar b2)]}
+     in translateFunctionExpr context1 inputIndex inputCounter e
+  -- Function with 1 input
+  Lam b e ->
+    let context1 = context {functionInputs = [(IRVar b)]}
+     in translateFunctionExpr context1 inputIndex inputCounter e
+  Let _ e -> translateFunctionExpr context inputIndex inputCounter e
+  Case (Var i) _ _ty alts -> case elemIndex (IRVar i) (functionInputs context) of
+    Just newInputIndex ->
+      let context1 = translateAltList context alts newInputIndex 0
+       in context1
+    Nothing ->
+      let context1 = translateAltList context alts inputIndex inputCounter
+       in context1
+  _ ->
+    let functionContentList = translateOutputExprToFunctionContentList context expr []
+        scopeStmt = translateFunctionContent context functionContentList
+        context1 = context {scope = scopeStmt}
+     in context1
 
---     = Var	  Id
---   | Lit   Literal
---   | App   (Expr b) (Arg b)
---   | Lam   b (Expr b)
---   | Let   (Bind b) (Expr b)
---   | Case  (Expr b) b Type [Alt b]
---   | Cast  (Expr b) Coercion
---   | Tick  (Tickish Id) (Expr b)
---   | Type  Type
---   | Coercion Coercion
+translateFunctionContent :: TranslationContext -> [FunctionContent] -> Statement
+translateFunctionContent context contentList =
+  let finalExprsStack = aux (emptyStack) contentList
+      stmtList = stackToScope (outputSignalIds context) [] finalExprsStack
+   in SScope stmtList
+  where
+    stackToScope :: [String] -> [Statement] -> Stack [Expression] -> [Statement]
+    stackToScope outputSignalList acc exprsStack = case (pop exprsStack) of
+      Nothing -> acc
+      Just (exprList, exprsStack1) ->
+        let (outputSignal, outputSignalTail) = case outputSignalList of
+              [] -> error "translateFunctionContent - insufficient output signals for expressions"
+              (output : outputTail) -> (output, outputTail)
+            outputStmts = map (\(idx, expr) -> SArrayAssign outputSignal (EInt idx) Nothing expr) (zip [0 ..] exprList)
+         in stackToScope outputSignalTail (acc ++ outputStmts) exprsStack1
+    aux :: (Stack [Expression]) -> [FunctionContent] -> (Stack [Expression])
+    aux exprsStack currentContentList = case currentContentList of
+      [] -> exprsStack
+      FList : contentTail ->
+        let newExprList = []
+            exprsStack1 = push newExprList exprsStack
+         in aux exprsStack1 contentTail
+      (FInt i) : contentTail ->
+        let (exprList, exprsStack1) = case (pop exprsStack) of
+              Nothing -> error "translateFunctionContent - empty expression stack when expecting expression list"
+              Just (elist, stack1) -> (elist, stack1)
+            expr = EInt i
+            newExprList = expr : exprList
+            exprsStack2 = push newExprList exprsStack1
+         in aux exprsStack2 contentTail
+      (FVar varId) : contentTail ->
+        let (exprList, exprsStack1) = case (pop exprsStack) of
+              Nothing -> error "translateFunctionContent - empty expression stack when expecting expression list"
+              Just (elist, stack1) -> (elist, stack1)
+            variableExpr = case lookup (IRVar varId) (functionVariables context) of
+              Just expr -> expr
+              Nothing -> error ("translateFunctionContent - variable not found: " ++ varToString varId)
+            newExprList = variableExpr : exprList
+            exprsStack2 = push newExprList exprsStack1
+         in aux exprsStack2 contentTail
+      FPlus : contentTail ->
+        let (exprList, exprsStack1) = case (pop exprsStack) of
+              Nothing -> error "translateFunctionContent - empty expression stack when expecting expression list"
+              Just (elist, stack1) -> (elist, stack1)
+            (expr1, expr2, exprTail) = case exprList of
+              (e1@(EBinOp _ _ _) : e2@(EBinOp _ _ _) : eTail) -> (EParen e1, EParen e2, eTail)
+              (e1@(EBinOp _ _ _) : e2 : eTail) -> (EParen e1, e2, eTail)
+              (e1 : e2@(EBinOp _ _ _) : eTail) -> (e1, EParen e2, eTail)
+              (e1 : e2 : eTail) -> (e1, e2, eTail)
+              _ -> error "translateFunctionContent - insufficient operands for Plus"
+            newExpr = EBinOp Plus expr1 expr2
+            newExprList = newExpr : exprTail
+            exprsStack2 = push newExprList exprsStack1
+         in aux exprsStack2 contentTail
+      FMinus : contentTail ->
+        let (exprList, exprsStack1) = case (pop exprsStack) of
+              Nothing -> error "translateFunctionContent - empty expression stack when expecting expression list"
+              Just (elist, stack1) -> (elist, stack1)
+            (expr1, expr2, exprTail) = case exprList of
+              (e1@(EBinOp _ _ _) : e2@(EBinOp _ _ _) : eTail) -> (EParen e1, EParen e2, eTail)
+              (e1@(EBinOp _ _ _) : e2 : eTail) -> (EParen e1, e2, eTail)
+              (e1 : e2@(EBinOp _ _ _) : eTail) -> (e1, EParen e2, eTail)
+              (e1 : e2 : eTail) -> (e1, e2, eTail)
+              _ -> error "translateFunctionContent - insufficient operands for Minus"
+            newExpr = EBinOp Minus expr1 expr2
+            newExprList = newExpr : exprTail
+            exprsStack2 = push newExprList exprsStack1
+         in aux exprsStack2 contentTail
+      FMultiply : contentTail ->
+        let (exprList, exprsStack1) = case (pop exprsStack) of
+              Nothing -> error "translateFunctionContent - empty expression stack when expecting expression list"
+              Just (elist, stack1) -> (elist, stack1)
+            (expr1, expr2, exprTail) = case exprList of
+              (e1@(EBinOp _ _ _) : e2@(EBinOp _ _ _) : eTail) -> (EParen e1, EParen e2, eTail)
+              (e1@(EBinOp _ _ _) : e2 : eTail) -> (EParen e1, e2, eTail)
+              (e1 : e2@(EBinOp _ _ _) : eTail) -> (e1, EParen e2, eTail)
+              (e1 : e2 : eTail) -> (e1, e2, eTail)
+              _ -> error "translateFunctionContent - insufficient operands for Multiply"
+            newExpr = EBinOp Multiply expr1 expr2
+            newExprList = newExpr : exprTail
+            exprsStack2 = push newExprList exprsStack1
+         in aux exprsStack2 contentTail
+      FDiv : contentTail ->
+        let (exprList, exprsStack1) = case (pop exprsStack) of
+              Nothing -> error "translateFunctionContent - empty expression stack when expecting expression list"
+              Just (elist, stack1) -> (elist, stack1)
+            (expr1, expr2, exprTail) = case exprList of
+              (e1@(EBinOp _ _ _) : e2@(EBinOp _ _ _) : eTail) -> (EParen e1, EParen e2, eTail)
+              (e1@(EBinOp _ _ _) : e2 : eTail) -> (EParen e1, e2, eTail)
+              (e1 : e2@(EBinOp _ _ _) : eTail) -> (e1, EParen e2, eTail)
+              (e1 : e2 : eTail) -> (e1, e2, eTail)
+              _ -> error "translateFunctionContent - insufficient operands for Div"
+            newExpr = EBinOp Divide expr1 expr2
+            newExprList = newExpr : exprTail
+            exprsStack2 = push newExprList exprsStack1
+         in aux exprsStack2 contentTail
+      FNegate : contentTail ->
+        let (exprList, exprsStack1) = case (pop exprsStack) of
+              Nothing -> error "translateFunctionContent - empty expression stack when expecting expression list"
+              Just (elist, stack1) -> (elist, stack1)
+            (expr1, exprTail) = case exprList of
+              (e1 : eTail) -> (e1, eTail)
+              _ -> error "translateFunctionContent - insufficient operands for Negate"
+            newExpr = EParen (EUnOp Negate expr1)
+            newExprList = newExpr : exprTail
+            exprsStack2 = push newExprList exprsStack1
+         in aux exprsStack2 contentTail
+      FColon : contentTail -> aux exprsStack contentTail
+      FTuple : contentTail -> aux exprsStack contentTail
 
--- type Arg b = Expr b
--- type Alt b = (AltCon, [b], Expr b)
+translateOutputExprToFunctionContentList :: TranslationContext -> CoreExpr -> [FunctionContent] -> [FunctionContent]
+translateOutputExprToFunctionContentList context expr acc = case expr of
+  App e a ->
+    let acc1 = translateOutputExprToFunctionContentList context e acc
+     in translateOutputExprToFunctionContentList context a acc1
+  (Var varId) -> case (showPpr (flags context)) varId of
+    ":" -> FColon : acc
+    "(,)" -> FTuple : acc
+    "(,,)" -> FTuple : acc
+    "(,,,)" -> FTuple : acc
+    "[]" -> FList : acc
+    "I#" -> acc
+    "$fNumInt" -> acc
+    "$fIntegralInt" -> acc
+    "+" -> FPlus : acc
+    "-" -> FMinus : acc
+    "*" -> FMultiply : acc
+    "div" -> FDiv : acc
+    "negate" -> FNegate : acc
+    _ -> FVar varId : acc
+  Lit i -> FInt (literalToInt i) : acc
+  _ -> acc
 
--- data AltCon = DataAlt DataCon | LitAlt  Literal | DEFAULT
-
--- data Bind b = NonRec b (Expr b) | Rec [(b, (Expr b))]
+translateAltList :: TranslationContext -> [Alt CoreBndr] -> Int -> Int -> TranslationContext
+translateAltList context alts inputIndex inputCounter = case alts of
+  [] -> context
+  (Alt (DataAlt dc) ids e) : altsTail -> case showPpr (flags context) dc of
+    "[]" ->
+      let context1 = translateFunctionExpr context inputIndex 0 e
+       in translateAltList context1 altsTail inputIndex inputCounter
+    ":" ->
+      let variableId = IRVar (ids !! 0)
+          variableExpression = (EArrayAccess (EVar ("input_" ++ show (inputIndex + 1))) (EInt inputCounter))
+          context1 = context {functionVariables = (variableId, variableExpression) : functionVariables context}
+          context2 = translateFunctionExpr context1 inputIndex (inputCounter + 1) e
+       in translateAltList context2 altsTail inputIndex inputCounter
+    _ -> error ("translateAltList - unsupported data alt: " ++ showPpr (flags context) dc)
+  (Alt DEFAULT _ _) : altsTail -> translateAltList context altsTail inputIndex inputCounter
+  alt : _ -> error ("translateAltList - unsupported alt: " ++ prettyCoreAlt (flags context) alt)

--- a/src/CoreIRToProceduralIR.hs
+++ b/src/CoreIRToProceduralIR.hs
@@ -9,45 +9,51 @@ import CoreIR (literalToInt, prettyCoreAlt, varToString)
 import Data.List (elemIndex)
 import Data.Maybe (listToMaybe, mapMaybe)
 import ForSyDeIR
-import GHC hiding (targetId)
+import GHC hiding (Type, targetId)
 import GHC.Core
 import GHC.Driver.Ppr (showPpr)
 import GHC.Plugins (Var)
 import ProceduralIR
 import Utilities (Stack, emptyStack, pop, push, stackToList)
 
+-- | The `TranslationContext` is a data type which is used to pass around
+-- context required to complete the translation of Core IR to Procedural IR.
 data TranslationContext = TranslationContext
-  { flags :: DynFlags,
-    inputSignalIds :: [String],
-    outputSignalIds :: [String],
-    functionInputs :: [IRId],
-    functionVariables :: [(IRId, Expression)],
-    scope :: Statement
+  { flags :: DynFlags, -- Stores `DynFlags` for safely obtaining strings
+    inputIds :: [String], -- List of input signal names
+    outputIds :: [String], -- List of output signal names
+    functionInputs :: [IRId], -- List of function inputs ids
+    functionVariables :: [(IRId, Expression)], -- Associated list of functionIds and expression
+    scope :: Statement -- Scope of function definition
   }
 
-initialTranslationContext :: DynFlags -> TranslationContext
-initialTranslationContext dflags =
-  TranslationContext
-    { flags = dflags,
-      inputSignalIds = [],
-      outputSignalIds = [],
-      functionInputs = [],
-      functionVariables = [],
-      scope = SScope []
-    }
-
+-- | The `FunctionContent` data type is used to represent the individual
+-- components that make up the contents of a function expression using Core IR.
 data FunctionContent
   = FVar Var
   | FInt Int
-  | FColon
+  | FCons
   | FTuple
-  | FList
+  | FEmptyList
   | FPlus
   | FMinus
   | FMultiply
   | FDiv
   | FNegate
 
+initialTranslationContext :: DynFlags -> TranslationContext
+initialTranslationContext dflags =
+  TranslationContext
+    { flags = dflags,
+      inputIds = [],
+      outputIds = [],
+      functionInputs = [],
+      functionVariables = [],
+      scope = SScope []
+    }
+
+-- | Translates an `IRFunction` into a Procedural IR function declaration and
+-- optional definition.
 translateIRFunction :: IRFunction -> DynFlags -> [IRConstructor] -> (Global, Maybe Global)
 translateIRFunction function dflags constructors =
   let context = initialTranslationContext dflags
@@ -69,28 +75,9 @@ translateIRFunction function dflags constructors =
               functionDefinitionGlobal = getFunctionDefinition context2 parameterList functionId
            in (functionDeclarationGlobal, Just functionDefinitionGlobal)
 
-getParameterList :: TranslationContext -> IRConstructor -> ([(ProceduralIR.Type, String)], TranslationContext)
-getParameterList context (IRActor _ _ _ (inputSignals, outputSignals)) =
-  let inputParameters = map (\(idx, _) -> (TPointer (TIdent "token"), "input_" ++ show idx)) (zip [1 :: Int ..] inputSignals)
-      outputParameters = map (\(idx, _) -> (TPointer (TIdent "token"), "output_" ++ show idx)) (zip [1 :: Int ..] outputSignals)
-      parametersList = inputParameters ++ outputParameters
-      inputSignalList = map snd inputParameters
-      outputSignalList = map snd outputParameters
-      context1 = context {inputSignalIds = inputSignalList, outputSignalIds = outputSignalList}
-   in (parametersList, context1)
-getParameterList context (IRDelay _ _ _) = ([], context)
-
-getFunctionDeclaration :: [(ProceduralIR.Type, String)] -> IRId -> Global
-getFunctionDeclaration parameterList functionId =
-  let functionDeclareGlobal = GFuncDeclare (Just Static) TVoid (show functionId) parameterList
-   in functionDeclareGlobal
-
-getFunctionDefinition :: TranslationContext -> [(ProceduralIR.Type, String)] -> IRId -> Global
-getFunctionDefinition context parametersList functionId =
-  let stmtScope = scope context
-      functionDefinitionGlobal = GFuncDef (Just Static) TVoid (show functionId) parametersList stmtScope
-   in functionDefinitionGlobal
-
+-- Helper function which identifies which `IRActor` is associated with a
+-- provided function id. If successful returns the actor as an optional
+-- `IRConstructor` otherwise returns `Nothing`.
 findActorFromFunctionId :: IRId -> [IRConstructor] -> Maybe IRConstructor
 findActorFromFunctionId targetFunctionId constructors =
   let checkIRConstructor :: IRConstructor -> Maybe IRConstructor
@@ -100,153 +87,115 @@ findActorFromFunctionId targetFunctionId constructors =
       checkIRConstructor _ = Nothing
    in listToMaybe (mapMaybe checkIRConstructor constructors)
 
+-- Helper function which builds the parameter list for a `ProceduralIR` function
+-- based on the input and output signals of provided actor. Updates the
+-- `TranslationContext` with the input and output ids.
+getParameterList :: TranslationContext -> IRConstructor -> ([(Type, String)], TranslationContext)
+getParameterList context (IRActor _ _ _ (inputSignals, outputSignals)) =
+  let inputParameters = map (\(index, _) -> (TPointer (TIdent "token"), "input_" ++ show index)) (zip [1 :: Int ..] inputSignals)
+      outputParameters = map (\(index, _) -> (TPointer (TIdent "token"), "output_" ++ show index)) (zip [1 :: Int ..] outputSignals)
+      parametersList = inputParameters ++ outputParameters
+      inputIdList = map snd inputParameters
+      outputIdList = map snd outputParameters
+      context1 = context {inputIds = inputIdList, outputIds = outputIdList}
+   in (parametersList, context1)
+getParameterList context (IRDelay _ _ _) = ([], context)
+
+getFunctionDeclaration :: [(Type, String)] -> IRId -> Global
+getFunctionDeclaration parameterList functionId =
+  let functionDeclareGlobal = GFuncDeclare (Just Static) TVoid (show functionId) parameterList
+   in functionDeclareGlobal
+
+getFunctionDefinition :: TranslationContext -> [(Type, String)] -> IRId -> Global
+getFunctionDefinition context parametersList functionId =
+  let stmtScope = scope context
+      functionDefinitionGlobal = GFuncDef (Just Static) TVoid (show functionId) parametersList stmtScope
+   in functionDefinitionGlobal
+
+-- | Translates the `CoreExpr` associated with an `IRFunction` into a Procedural
+-- IR scope. The input id argument represents the current input being pattern
+-- matched. The input index argument represents index of the input the pattern
+-- matched binder represents.
 translateFunctionExpr :: TranslationContext -> Int -> Int -> CoreExpr -> TranslationContext
-translateFunctionExpr context inputIndex inputCounter expr = case expr of
+translateFunctionExpr context inputId inputIndex expr = case expr of
   -- Function with 4 inputs
   Lam b1 (Lam b2 (Lam b3 (Lam b4 e))) ->
     let context1 = context {functionInputs = [(IRVar b1), (IRVar b2), (IRVar b3), (IRVar b4)]}
-     in translateFunctionExpr context1 inputIndex inputCounter e
+     in translateFunctionExpr context1 inputId inputIndex e
   -- Function with 3 inputs
   Lam b1 (Lam b2 (Lam b3 e)) ->
     let context1 = context {functionInputs = [(IRVar b1), (IRVar b2), (IRVar b3)]}
-     in translateFunctionExpr context1 inputIndex inputCounter e
+     in translateFunctionExpr context1 inputId inputIndex e
   -- Function with 2 inputs
   Lam b1 (Lam b2 e) ->
     let context1 = context {functionInputs = [(IRVar b1), (IRVar b2)]}
-     in translateFunctionExpr context1 inputIndex inputCounter e
+     in translateFunctionExpr context1 inputId inputIndex e
   -- Function with 1 input
   Lam b e ->
     let context1 = context {functionInputs = [(IRVar b)]}
-     in translateFunctionExpr context1 inputIndex inputCounter e
-  Let _ e -> translateFunctionExpr context inputIndex inputCounter e
+     in translateFunctionExpr context1 inputId inputIndex e
+  Let _ e -> translateFunctionExpr context inputId inputIndex e
+  -- The Core IR `Case` data type is used in function expressions to pattern
+  -- match on a functions inputs. Checks if the current binder being pattern
+  -- matched is a function input and get its index.
   Case (Var i) _ _ty alts -> case elemIndex (IRVar i) (functionInputs context) of
-    Just newInputIndex ->
-      let context1 = translateAltList context alts newInputIndex 0
+    -- The index of an input in the function inputs list is used to id the input
+    -- in Procedural IR.
+    Just newInputId ->
+      -- Pattern matching on a new function input pass new input id and reset
+      -- index to zero
+      let context1 = translateAltList context alts newInputId 0
        in context1
     Nothing ->
-      let context1 = translateAltList context alts inputIndex inputCounter
+      -- Still pattern maching on previous function input continue passing
+      -- current input id and increment input index
+      let context1 = translateAltList context alts inputId (inputIndex + 1)
        in context1
+  -- Reached the main content of the function
   _ ->
     let functionContentList = translateOutputExprToFunctionContentList context expr []
         scopeStmt = translateFunctionContent context functionContentList
         context1 = context {scope = scopeStmt}
      in context1
 
-translateFunctionContent :: TranslationContext -> [FunctionContent] -> Statement
-translateFunctionContent context contentList =
-  let finalExprsStack = foldl' functionContentToStack emptyStack contentList
-      stmtList = foldl' stackToScope [] (zip (outputSignalIds context) (stackToList finalExprsStack))
-   in SScope stmtList
-  where
-    stackToScope :: [Statement] -> (String, [Expression]) -> [Statement]
-    stackToScope acc (outputSignal, exprList) =
-      let outputStmts = map (\(idx, expr) -> SArrayAssign outputSignal (EInt idx) Nothing expr) (zip [0 ..] exprList)
-       in (acc ++ outputStmts)
-    functionContentToStack :: (Stack [Expression]) -> FunctionContent -> (Stack [Expression])
-    functionContentToStack exprsStack content = case content of
-      FList ->
-        let newExprList = []
-            exprsStack1 = push newExprList exprsStack
-         in exprsStack1
-      (FInt i) ->
-        let (exprList, exprsStack1) = case (pop exprsStack) of
-              Nothing -> error "translateFunctionContent - empty expression stack when expecting expression list"
-              Just (elist, stack1) -> (elist, stack1)
-            expr = EInt i
-            newExprList = expr : exprList
-            exprsStack2 = push newExprList exprsStack1
-         in exprsStack2
-      (FVar varId) ->
-        let (exprList, exprsStack1) = case (pop exprsStack) of
-              Nothing -> error "translateFunctionContent - empty expression stack when expecting expression list"
-              Just (elist, stack1) -> (elist, stack1)
-            variableExpr = case lookup (IRVar varId) (functionVariables context) of
-              Just expr -> expr
-              Nothing -> error ("translateFunctionContent - variable not found: " ++ varToString varId)
-            newExprList = variableExpr : exprList
-            exprsStack2 = push newExprList exprsStack1
-         in exprsStack2
-      FPlus ->
-        let (exprList, exprsStack1) = case (pop exprsStack) of
-              Nothing -> error "translateFunctionContent - empty expression stack when expecting expression list"
-              Just (elist, stack1) -> (elist, stack1)
-            (expr1, expr2, exprTail) = case exprList of
-              (e1@(EBinOp _ _ _) : e2@(EBinOp _ _ _) : eTail) -> (EParen e1, EParen e2, eTail)
-              (e1@(EBinOp _ _ _) : e2 : eTail) -> (EParen e1, e2, eTail)
-              (e1 : e2@(EBinOp _ _ _) : eTail) -> (e1, EParen e2, eTail)
-              (e1 : e2 : eTail) -> (e1, e2, eTail)
-              _ -> error "translateFunctionContent - insufficient operands for Plus"
-            newExpr = EBinOp Plus expr1 expr2
-            newExprList = newExpr : exprTail
-            exprsStack2 = push newExprList exprsStack1
-         in exprsStack2
-      FMinus ->
-        let (exprList, exprsStack1) = case (pop exprsStack) of
-              Nothing -> error "translateFunctionContent - empty expression stack when expecting expression list"
-              Just (elist, stack1) -> (elist, stack1)
-            (expr1, expr2, exprTail) = case exprList of
-              (e1@(EBinOp _ _ _) : e2@(EBinOp _ _ _) : eTail) -> (EParen e1, EParen e2, eTail)
-              (e1@(EBinOp _ _ _) : e2 : eTail) -> (EParen e1, e2, eTail)
-              (e1 : e2@(EBinOp _ _ _) : eTail) -> (e1, EParen e2, eTail)
-              (e1 : e2 : eTail) -> (e1, e2, eTail)
-              _ -> error "translateFunctionContent - insufficient operands for Minus"
-            newExpr = EBinOp Minus expr1 expr2
-            newExprList = newExpr : exprTail
-            exprsStack2 = push newExprList exprsStack1
-         in exprsStack2
-      FMultiply ->
-        let (exprList, exprsStack1) = case (pop exprsStack) of
-              Nothing -> error "translateFunctionContent - empty expression stack when expecting expression list"
-              Just (elist, stack1) -> (elist, stack1)
-            (expr1, expr2, exprTail) = case exprList of
-              (e1@(EBinOp _ _ _) : e2@(EBinOp _ _ _) : eTail) -> (EParen e1, EParen e2, eTail)
-              (e1@(EBinOp _ _ _) : e2 : eTail) -> (EParen e1, e2, eTail)
-              (e1 : e2@(EBinOp _ _ _) : eTail) -> (e1, EParen e2, eTail)
-              (e1 : e2 : eTail) -> (e1, e2, eTail)
-              _ -> error "translateFunctionContent - insufficient operands for Multiply"
-            newExpr = EBinOp Multiply expr1 expr2
-            newExprList = newExpr : exprTail
-            exprsStack2 = push newExprList exprsStack1
-         in exprsStack2
-      FDiv ->
-        let (exprList, exprsStack1) = case (pop exprsStack) of
-              Nothing -> error "translateFunctionContent - empty expression stack when expecting expression list"
-              Just (elist, stack1) -> (elist, stack1)
-            (expr1, expr2, exprTail) = case exprList of
-              (e1@(EBinOp _ _ _) : e2@(EBinOp _ _ _) : eTail) -> (EParen e1, EParen e2, eTail)
-              (e1@(EBinOp _ _ _) : e2 : eTail) -> (EParen e1, e2, eTail)
-              (e1 : e2@(EBinOp _ _ _) : eTail) -> (e1, EParen e2, eTail)
-              (e1 : e2 : eTail) -> (e1, e2, eTail)
-              _ -> error "translateFunctionContent - insufficient operands for Div"
-            newExpr = EBinOp Divide expr1 expr2
-            newExprList = newExpr : exprTail
-            exprsStack2 = push newExprList exprsStack1
-         in exprsStack2
-      FNegate ->
-        let (exprList, exprsStack1) = case (pop exprsStack) of
-              Nothing -> error "translateFunctionContent - empty expression stack when expecting expression list"
-              Just (elist, stack1) -> (elist, stack1)
-            (expr1, exprTail) = case exprList of
-              (e1 : eTail) -> (e1, eTail)
-              _ -> error "translateFunctionContent - insufficient operands for Negate"
-            newExpr = EParen (EUnOp Negate expr1)
-            newExprList = newExpr : exprTail
-            exprsStack2 = push newExprList exprsStack1
-         in exprsStack2
-      FColon -> exprsStack
-      FTuple -> exprsStack
+-- | Helper function which identifies a binder as a function input and updates
+-- the translation context with its associated Procedural IR expression
+translateAltList :: TranslationContext -> [Alt CoreBndr] -> Int -> Int -> TranslationContext
+translateAltList context alts inputId inputIndex = case alts of
+  [] -> context
+  (Alt (DataAlt dc) ids e) : altsTail -> case showPpr (flags context) dc of
+    -- An empty list pattern match indicates the end of function input
+    "[]" ->
+      let context1 = translateFunctionExpr context inputId inputIndex e
+       in translateAltList context1 altsTail inputId inputIndex
+    -- A cons pattern match indicates a new function input, the following
+    -- builds the associated variable expression for the input and updates the
+    -- translation context
+    ":" ->
+      let variableId = IRVar (ids !! 0)
+          variableExpression = (EArrayAccess (EVar ("input_" ++ show (inputId + 1))) (EInt inputIndex))
+          context1 = context {functionVariables = (variableId, variableExpression) : functionVariables context}
+          context2 = translateFunctionExpr context1 inputId inputIndex e
+       in translateAltList context2 altsTail inputId inputIndex
+    _ -> error ("translateAltList - unsupported data alt: " ++ showPpr (flags context) dc)
+  -- Skip DEFAULT pattern match, ignoring base case since not translating errors
+  (Alt DEFAULT _ _) : altsTail -> translateAltList context altsTail inputId inputIndex
+  alt : _ -> error ("translateAltList - unsupported alt: " ++ prettyCoreAlt (flags context) alt)
 
+-- | Translates the main `CoreExpr` of an `IRFunction` into a list of
+-- `FunctionContent`. The returned `FunctionContent` list is in reverse polish
+-- notation.
 translateOutputExprToFunctionContentList :: TranslationContext -> CoreExpr -> [FunctionContent] -> [FunctionContent]
 translateOutputExprToFunctionContentList context expr acc = case expr of
   App e a ->
     let acc1 = translateOutputExprToFunctionContentList context e acc
      in translateOutputExprToFunctionContentList context a acc1
   (Var varId) -> case (showPpr (flags context)) varId of
-    ":" -> FColon : acc
+    ":" -> FCons : acc
     "(,)" -> FTuple : acc
     "(,,)" -> FTuple : acc
     "(,,,)" -> FTuple : acc
-    "[]" -> FList : acc
+    "[]" -> FEmptyList : acc
     "I#" -> acc
     "$fNumInt" -> acc
     "$fIntegralInt" -> acc
@@ -259,19 +208,83 @@ translateOutputExprToFunctionContentList context expr acc = case expr of
   Lit i -> FInt (literalToInt i) : acc
   _ -> acc
 
-translateAltList :: TranslationContext -> [Alt CoreBndr] -> Int -> Int -> TranslationContext
-translateAltList context alts inputIndex inputCounter = case alts of
-  [] -> context
-  (Alt (DataAlt dc) ids e) : altsTail -> case showPpr (flags context) dc of
-    "[]" ->
-      let context1 = translateFunctionExpr context inputIndex 0 e
-       in translateAltList context1 altsTail inputIndex inputCounter
-    ":" ->
-      let variableId = IRVar (ids !! 0)
-          variableExpression = (EArrayAccess (EVar ("input_" ++ show (inputIndex + 1))) (EInt inputCounter))
-          context1 = context {functionVariables = (variableId, variableExpression) : functionVariables context}
-          context2 = translateFunctionExpr context1 inputIndex (inputCounter + 1) e
-       in translateAltList context2 altsTail inputIndex inputCounter
-    _ -> error ("translateAltList - unsupported data alt: " ++ showPpr (flags context) dc)
-  (Alt DEFAULT _ _) : altsTail -> translateAltList context altsTail inputIndex inputCounter
-  alt : _ -> error ("translateAltList - unsupported alt: " ++ prettyCoreAlt (flags context) alt)
+-- | Translates a `FunctionContent` list into a Procedural IR scope.
+translateFunctionContent :: TranslationContext -> [FunctionContent] -> Statement
+translateFunctionContent context contentList =
+  let finalExprsStack = foldl' functionContentToStack emptyStack contentList
+      stmtList = foldl' stackToScope [] (zip (outputIds context) (stackToList finalExprsStack))
+   in SScope stmtList
+  where
+    -- Helper function which translates an associated output signal id and a
+    -- list of expressions into a list of statements. Each statement in the list
+    -- represents an array assign of the output at an incrementing index equal
+    -- to an expression.
+    stackToScope :: [Statement] -> (String, [Expression]) -> [Statement]
+    stackToScope acc (outputSignal, exprList) =
+      let outputStmts = map (\(idx, expr) -> SArrayAssign outputSignal (EInt idx) Nothing expr) (zip [0 ..] exprList)
+       in (acc ++ outputStmts)
+    -- Helper function which wraps Procedural IR expression which use non
+    -- commutative binary or unary operators in parenthesis.
+    wrapNonCommutativeExpression :: Expression -> Expression
+    wrapNonCommutativeExpression e = case e of
+      EBinOp Minus _ _ -> EParen e
+      EBinOp Divide _ _ -> EParen e
+      EUnOp Negate _ -> EParen e
+      _ -> e
+    -- Helper function to handle the case when the `FunctionContent` represents
+    -- a `BinaryOperator`
+    binOpContentToStack :: BinaryOperator -> Stack [Expression] -> Stack [Expression]
+    binOpContentToStack binOp exprsStack =
+      let (exprList, exprsStack1) = case (pop exprsStack) of
+            Nothing -> error "translateFunctionContent - empty expression stack when popping"
+            Just (elist, stack1) -> (elist, stack1)
+          (expr1, expr2, exprTail) = case exprList of
+            (e1 : e2 : eTail) -> (wrapNonCommutativeExpression e1, wrapNonCommutativeExpression e2, eTail)
+            _ -> error ("translateFunctionContent - insufficient operands for " ++ show binOp)
+          newExpr = EBinOp binOp expr1 expr2
+          newExprList = newExpr : exprTail
+          exprsStack2 = push newExprList exprsStack1
+       in exprsStack2
+    -- Help function which uses a stack to convert a `FunctionContent` the
+    -- Procedural IR `Expression` it represents
+    functionContentToStack :: (Stack [Expression]) -> FunctionContent -> (Stack [Expression])
+    functionContentToStack exprsStack content = case content of
+      FEmptyList ->
+        let newExprList = []
+            exprsStack1 = push newExprList exprsStack
+         in exprsStack1
+      (FInt i) ->
+        let (exprList, exprsStack1) = case (pop exprsStack) of
+              Nothing -> error "translateFunctionContent - empty expression stack when popping"
+              Just (elist, stack1) -> (elist, stack1)
+            expr = EInt i
+            newExprList = expr : exprList
+            exprsStack2 = push newExprList exprsStack1
+         in exprsStack2
+      (FVar varId) ->
+        let (exprList, exprsStack1) = case (pop exprsStack) of
+              Nothing -> error "translateFunctionContent - empty expression stack when popping"
+              Just (elist, stack1) -> (elist, stack1)
+            variableExpr = case lookup (IRVar varId) (functionVariables context) of
+              Just expr -> expr
+              Nothing -> error ("translateFunctionContent - variable not found: " ++ varToString varId)
+            newExprList = variableExpr : exprList
+            exprsStack2 = push newExprList exprsStack1
+         in exprsStack2
+      FPlus -> binOpContentToStack Plus exprsStack
+      FMinus -> binOpContentToStack Minus exprsStack
+      FMultiply -> binOpContentToStack Multiply exprsStack
+      FDiv -> binOpContentToStack Divide exprsStack
+      FNegate ->
+        let (exprList, exprsStack1) = case (pop exprsStack) of
+              Nothing -> error "translateFunctionContent - empty expression stack when popping"
+              Just (elist, stack1) -> (elist, stack1)
+            (expr1, exprTail) = case exprList of
+              (e1 : eTail) -> (e1, eTail)
+              _ -> error "translateFunctionContent - insufficient operands for Negate"
+            newExpr = EUnOp Negate expr1
+            newExprList = newExpr : exprTail
+            exprsStack2 = push newExprList exprsStack1
+         in exprsStack2
+      FCons -> exprsStack
+      FTuple -> exprsStack

--- a/src/ForSyDeIR.hs
+++ b/src/ForSyDeIR.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -42,6 +43,7 @@ data IRId
   | Empty
 
 instance Show IRId where
+  show :: IRId -> String
   show (IRVar i) = varToString i
   show (IRString s) = s
   show Empty = ""

--- a/src/ForSyDeIRToProceduralIR.hs
+++ b/src/ForSyDeIRToProceduralIR.hs
@@ -203,7 +203,7 @@ translateIRConstructor initialContext constructor = case constructor of
                     (EBinOp Less (EVar "i") (EInt (bufferSize)))
                     (SExpr (EUnOp Increment (EVar "i")))
                     (SScope [SVarAssign "status" (ECall "scanf" [EString "%d", EReference (EArrayAccess (EVar ("input_" ++ show signalId)) (EVar "i"))])])
-                breakIfStmt = SIf (EBinOp Less (EVar "status") (EInt 1)) (SBreak) Nothing
+                breakIfStmt = SIf (EBinOp Less (EVar "status") (EInt 1)) (SScope [SBreak]) Nothing
                 writeForStmt =
                   SFor
                     (SVarDef TInt "i" (EInt 0))

--- a/src/ForSyDeIRToProceduralIR.hs
+++ b/src/ForSyDeIRToProceduralIR.hs
@@ -2,6 +2,7 @@ module ForSyDeIRToProceduralIR where
 
 import ArgumentsMain (InputType (Predefined, StdIn), Runs (Limited, Perpetual))
 import CoreIR (literalToInt, prettyCoreExpr, varToString)
+import CoreIRToProceduralIR (translateIRFunction)
 import ForSyDeIR
 import GHC hiding (targetId)
 import GHC.Core
@@ -56,7 +57,7 @@ translateIRSystemToProgram dflags scheduleList bufferList delayBufferList lookup
   let initialContext = initialTranslationContext dflags input r lookupSignalList inputList outputList delayBufferList
       context1 = foldl' translateIRConstructor initialContext constructors
       context2 = foldl' translateBuffer context1 bufferList
-      context3 = foldl' translateIRFunctionToGlobals context2 functionList
+      context3 = foldl' (translateIRFunctionToGlobals constructors) context2 functionList
       main = translateContextToMain context3 scheduleList
    in Prog (reverse (initFunctions context3) ++ [main] ++ reverse (functions context3))
 
@@ -276,13 +277,14 @@ getTargetRate context signalId =
         Just (IRSignal _ _ (_, rate)) -> rate
         Nothing -> error ("getTargetRate - signal not found: " ++ show signalId)
 
-translateIRFunctionToGlobals :: TranslationContext -> IRFunction -> TranslationContext
-translateIRFunctionToGlobals currentContext (IRFunction functionId maybeFunction) = case maybeFunction of
-  Just function ->
-    let (initFunctionGlobal, functionGlobal) = translateCoreExprToGlobals currentContext functionId function
-        context1 = currentContext {initFunctions = initFunctionGlobal : (initFunctions currentContext), functions = functionGlobal : (functions currentContext)}
-     in context1
-  Nothing -> currentContext
+translateIRFunctionToGlobals :: [IRConstructor] -> TranslationContext -> IRFunction -> TranslationContext
+translateIRFunctionToGlobals constructors currentContext function =
+  let context1 = case (translateIRFunction function (flags currentContext) constructors) of
+        (Just functionDeclaration, Just functionDefinition) -> currentContext {initFunctions = functionDeclaration : (initFunctions currentContext), functions = functionDefinition : (functions currentContext)}
+        (Just functionDeclaration, Nothing) -> currentContext {initFunctions = functionDeclaration : (initFunctions currentContext)}
+        (Nothing, Nothing) -> currentContext
+        _ -> error ("translateIRFunctionToGlobals - unsupported function:\n" ++ prettyIRFunction (flags currentContext) function)
+   in context1
 
 -- The following is a temporary hard coded solution that translates the inputs
 -- of the `add` and `accummulate` functions from SDF example 8.

--- a/src/ForSyDeIRToProceduralIR.hs
+++ b/src/ForSyDeIRToProceduralIR.hs
@@ -280,10 +280,8 @@ getTargetRate context signalId =
 translateIRFunctionToGlobals :: [IRConstructor] -> TranslationContext -> IRFunction -> TranslationContext
 translateIRFunctionToGlobals constructors currentContext function =
   let context1 = case (translateIRFunction function (flags currentContext) constructors) of
-        (Just functionDeclaration, Just functionDefinition) -> currentContext {initFunctions = functionDeclaration : (initFunctions currentContext), functions = functionDefinition : (functions currentContext)}
-        (Just functionDeclaration, Nothing) -> currentContext {initFunctions = functionDeclaration : (initFunctions currentContext)}
-        (Nothing, Nothing) -> currentContext
-        _ -> error ("translateIRFunctionToGlobals - unsupported function:\n" ++ prettyIRFunction (flags currentContext) function)
+        (functionDeclaration, Just functionDefinition) -> currentContext {initFunctions = functionDeclaration : (initFunctions currentContext), functions = functionDefinition : (functions currentContext)}
+        (functionDeclaration, Nothing) -> currentContext {initFunctions = functionDeclaration : (initFunctions currentContext)}
    in context1
 
 -- The following is a temporary hard coded solution that translates the inputs

--- a/src/ProceduralIR.hs
+++ b/src/ProceduralIR.hs
@@ -39,6 +39,7 @@ data UnaryOperator
   | LogicalNot -- !rhs
   | Increment -- ++rhs
   | Decrement -- --rhs
+  deriving (Show)
 
 data BinaryOperator
   = Plus -- lhs + rhs
@@ -89,6 +90,7 @@ data Expression
   | EMemberAccess Expression String -- expr.string
   | EPointerAccess Expression String -- expr->string
   | EParen Expression -- (expr)
+  deriving (Show)
 
 -- Statements
 data Statement

--- a/src/Utilities.hs
+++ b/src/Utilities.hs
@@ -9,6 +9,7 @@ module Utilities
     pop,
     peek,
     isEmpty,
+    stackToList,
   )
 where
 
@@ -43,6 +44,9 @@ peek (Stack (x : _)) = Just x
 isEmpty :: Stack a -> Bool
 isEmpty (Stack []) = True
 isEmpty (Stack _) = False
+
+stackToList :: Stack a -> [a]
+stackToList (Stack list) = list
 
 -- | Custom `compileToCore` function which compiles a haskell module at a
 -- specified file path into GHC Core. Returns a `CoreProgram` and the internally

--- a/src/Utilities.hs
+++ b/src/Utilities.hs
@@ -1,4 +1,16 @@
-module Utilities (compileToCore, compileToCoreWithForSyDePath, noInlineTypecheck, scheduleAndBuffer) where
+module Utilities
+  ( compileToCore,
+    compileToCoreWithForSyDePath,
+    noInlineTypecheck,
+    scheduleAndBuffer,
+    Stack,
+    emptyStack,
+    push,
+    pop,
+    peek,
+    isEmpty,
+  )
+where
 
 import CoreIRToForSyDeIR (translateCoreProgram)
 import Data.Data (Data, gmapT)
@@ -7,10 +19,30 @@ import ForSyDeIR (IRId (..))
 import GHC
 import GHC.Driver.Main
 import GHC.Paths (libdir)
-import GHC.Plugins
+import GHC.Plugins hiding (isEmpty)
 import GHC.Tc.Types
 import SDFSchedule (computeScheduleAndBuffers)
 import System.FilePath (takeBaseName)
+
+newtype Stack a = Stack [a] deriving (Show, Eq)
+
+emptyStack :: Stack a
+emptyStack = Stack []
+
+push :: a -> Stack a -> Stack a
+push x (Stack xs) = Stack (x : xs)
+
+pop :: Stack a -> Maybe (a, Stack a)
+pop (Stack []) = Nothing
+pop (Stack (x : xs)) = Just (x, Stack xs)
+
+peek :: Stack a -> Maybe a
+peek (Stack []) = Nothing
+peek (Stack (x : _)) = Just x
+
+isEmpty :: Stack a -> Bool
+isEmpty (Stack []) = True
+isEmpty (Stack _) = False
 
 -- | Custom `compileToCore` function which compiles a haskell module at a
 -- specified file path into GHC Core. Returns a `CoreProgram` and the internally

--- a/src/Utilities.hs
+++ b/src/Utilities.hs
@@ -89,7 +89,7 @@ compileToCoreWithForSyDePath forSyDePath filePath = runGhc (Just libdir) $ do
 
 -- | Updates all bindings within the function called `system` and adds NOINLINE
 -- pragmas. Prevents the pre optimisier run during desugaring from inlining
--- bindings relating to variables and functions within the compiled net list.
+-- bindings relating to variables and functions within the compiled netlist.
 --
 -- Solution is inspired by discussions from the GHC API issue:
 -- https://gitlab.haskell.org/ghc/ghc/-/issues/24386


### PR DESCRIPTION
Adds functionality to translate IRFunctions from ForSyDe IR into Procedural IR.
- Adds a module which translates Core IR function expressions into Procedural IR
- Adds various SDF examples used for testing
- Makes C the default output of the compiler
