### PR TITLE
Fix indexing in flattened arrays for predefined input

### DIFF
--- a/docs/c-code-templates.md
+++ b/docs/c-code-templates.md
@@ -119,6 +119,18 @@ int run_current = 0;
 int run_max = {x};
 ```
 
+In `predefined` mode, a cumulative iteration variable needs to be created for every actor that
+takes inputs. This is due to the fact that an input actor can take input tokens at multiple
+occasions in the period. Declare them with the name `i_` followed by the signal name,
+for instance
+
+```C
+int i_s_in_b = 0;
+int i_s_in_a = 0;
+```
+
+for the signals `s_in_b`, `s_in_a`.
+
 ### Input/Output tokens
 
 This section should be followed by a declaration of arrays for input/output tokens:
@@ -128,25 +140,20 @@ and read a token into this scalar each iteration of the loop. This means that on
 `output` variable can be created regardless of how many outputs the graph features.
 
 - The input tokens should be of type `token *`, and a unique array needs to be created
-for every input in the graph. The inputs will need to be processed for the whole period
-at once, which means that the (static) length of each array will need to be equal to
-tokens consumed per firing, multiplied by that actors value in the repetition vector.
-The input arrays should **only** be declared in `stdin` IO mode, and should be ommitted
-in the `predefined` mode since they are already defined in the `input.h` file.
+for every input in the graph. The input arrays should **only** be declared in `stdin` input mode,
+and should be ommitted in the `predefined` mode since they are already defined in the `input.h` file.
 
 Example:
 
-- `input_a` input for actor A. A consumes 2 tokens from input each time, and is ran 2
-times per schedule: `2*2 -> 4`
-- `input_b` input for actor B. B consumes 1 token from input each time, and is ran 1
-time per schedule.
-
 ```C
 // Temporary tokens for print/scan functions for input and output
-token input_a[4];
+token input_a[2];
 token input_b[1];
 token output;
 ```
+
+where `input_a` for actor a requires 2 tokens per firing and `input_b` for actor b requires 1 token
+per firing.
 
 ### Buffers
 
@@ -196,23 +203,20 @@ following 3 steps:
 Example:
 
 ```C
-for (i = 0; i < 4; i++) {
+for (i = 0; i < 2; i++) {
     ret = scanf("%d", &input_a[i]);
 }
 if (ret < 1) {
     break;
 }
-for(i = 0; i < 4; i++) {
+for(i = 0; i < 2; i++) {
     write_token(s_in_a, input_a[i]);
 }
 ```
 
 where `%d` needs to be replaced in case another data type than decimal is read.
-Similarly as [Input/Output tokens](#inputoutput-tokens), the upper bound on the
-for-loop for (1.) needs to consider how many times this input needs every firing,
-and how many times this buffer will be read from per period. In this example,
-2 tokens are consumed from `input_a` each time the actor fires, and the actor
-fires 2 times per schedule meaning 4 tokens need to be read per period.
+The upper bound on the for-loop for (1.) needs to consider how many tokens this
+input needs every firing.
 
 For (2.), only the final `scanf` return value is checked for that particular
 input, which will break out of the main while-loop. Afterwards for (3.), a
@@ -226,12 +230,13 @@ schedule, so the `write_token` needs to subindex within a period. This is done w
 for example:
 
 ```C
-for(i = 0; i < 4; i++) {
-    write_token(s_in_a, input_a[iteration_current * 4 + i]);
+for(i = 0; i < 2; i++) {
+    write_token(s_in_a, input_s_in_a[iteration_current * 4 + i_s_in_a]);
+    i_s_in_a = i_s_in_a + 1;
 }
 ```
 
-since each period contains 4 tokens of data.
+since each period contains 4 tokens of data, where only 2 tokens are consumed each firing.
 
 #### Schedule
 
@@ -275,20 +280,27 @@ printf("\n");
 
 #### Predefined input
 
-If in `predefined` input mode with runs set to `inf`, it needs to be checked whether all the data has
-been consumed. Start by incrementing the iteration counter, and then wrap
-the value back to 0 if all inputs have been consumed:
+If in `predefined` input mode with runs set to `inf`, it needs to be checked
+whether all the data has been consumed. Start by incrementing the iteration
+counter, and then wrap the value back to 0 if all inputs have been consumed:
 
 ```C
- iteration_current = iteration_current + 1;
- if (iteration_current == iteration_max) {
-     iteration_current = 0;
- }
+iteration_current = iteration_current + 1;
+i_s_in_b = 0;
+i_s_in_a = 0;
+if (iteration_current == iteration_max) {
+    iteration_current = 0;
+}
 ```
+The accumulating subindices for the flattened array `i_s_in_b` and
+`i_s_in_a` need to be reset to 0 since the period is over.
 
 In the case where runs is set to `runs={x}`, then use the following code block
 
 ```C
+iteration_current = iteration_current + 1;
+i_s_in_b = 0;
+i_s_in_a = 0;
 if (iteration_current == iteration_max) {
     iteration_current = 0;
     run_current = run_current + 1;

--- a/src/ForSyDeIRToProceduralIR.hs
+++ b/src/ForSyDeIRToProceduralIR.hs
@@ -21,6 +21,7 @@ data TranslationContext = TranslationContext
     ioTokens :: [Statement], -- List of statements for input/output tokens
     initBuffers :: [Statement], -- List of statements for initialising signal buffers
     freeBuffers :: [Statement], -- List of statements for freeing signal buffers
+    schedulerBufferList :: [(IRId, Int)], -- The buffer list that comes from the schedule
     systemInputs :: [IRId], -- List of system inputs
     systemOutputs :: [IRId], -- List of system outputs
     delayBuffers :: [(IRId, IRId)], -- Associated list of signal ids and buffer name for delay signals
@@ -29,8 +30,8 @@ data TranslationContext = TranslationContext
     functions :: [Global]
   }
 
-initialTranslationContext :: DynFlags -> InputType -> Runs -> [(IRId, IRSignal)] -> [IRId] -> [IRId] -> [(IRId, IRId)] -> TranslationContext
-initialTranslationContext dflags input r lookupSignalList inputList outputList delayBufferList =
+initialTranslationContext :: DynFlags -> InputType -> Runs -> [(IRId, IRSignal)] -> [(IRId, Int)] -> [IRId] -> [IRId] -> [(IRId, IRId)] -> TranslationContext
+initialTranslationContext dflags input r lookupSignalList bList inputList outputList delayBufferList =
   TranslationContext
     { flags = dflags,
       inputType = input,
@@ -41,6 +42,7 @@ initialTranslationContext dflags input r lookupSignalList inputList outputList d
       ioTokens = [],
       initBuffers = [],
       freeBuffers = [],
+      schedulerBufferList = bList,
       systemInputs = inputList,
       systemOutputs = outputList,
       delayBuffers = delayBufferList,
@@ -54,7 +56,7 @@ initialTranslationContext dflags input r lookupSignalList inputList outputList d
 -- input. Also requires an associated list of signals for lookups.
 translateIRSystemToProgram :: DynFlags -> [IRId] -> [(IRId, Int)] -> [(IRId, IRId)] -> [(IRId, IRSignal)] -> InputType -> Runs -> IRSystem -> Program
 translateIRSystemToProgram dflags scheduleList bufferList delayBufferList lookupSignalList input r (IRSystem (inputList, outputList) constructors _signalList functionList) =
-  let initialContext = initialTranslationContext dflags input r lookupSignalList inputList outputList delayBufferList
+  let initialContext = initialTranslationContext dflags input r lookupSignalList bufferList inputList outputList delayBufferList
       context1 = foldl' translateIRConstructor initialContext constructors
       context2 = foldl' translateBuffer context1 bufferList
       context3 = foldl' (translateIRFunctionToGlobals constructors) context2 functionList
@@ -68,17 +70,26 @@ translateContextToMain context scheduleList =
       scheduledInputStmts = case ((inputType context), (runs context)) of
         (StdIn, _) -> []
         (Predefined, Perpetual) ->
-          [ SVarAssign "iteration_current" (EBinOp Plus (EVar "iteration_current") (EInt 1)),
-            SIf (EBinOp Equal (EVar "iteration_current") (EVar "iteration_max")) (SScope [SVarAssign "iteration_current" (EInt 0)]) Nothing
-          ]
+          [SVarAssign "iteration_current" (EBinOp Plus (EVar "iteration_current") (EInt 1))]
+            ++ (foldl' resetIterationVariablesFromInputs [] (systemInputs context))
+            ++ [ SIf (EBinOp Equal (EVar "iteration_current") (EVar "iteration_max")) (SScope [SVarAssign "iteration_current" (EInt 0)]) Nothing
+               ]
         (Predefined, Limited _) ->
-          -- [ SVarAssign "iteration_current" (EBinOp Plus (EVar "iteration_current") (EInt 1)),
-          --  SIf (EBinOp Equal (EVar "iteration_current") (EVar "iteration_max")) (SVarAssign "iteration_current" (EInt 0)) Nothing,
-          --  SVarAssign "run_current" (EBinOp Plus (EVar "run_current") (EInt 1))
-          -- ]
-          [ SVarAssign "iteration_current" (EBinOp Plus (EVar "iteration_current") (EInt 1)),
-            SIf (EBinOp Equal (EVar "iteration_current") (EVar "iteration_max")) (SScope [SVarAssign "iteration_current" (EInt 0), SVarAssign "run_current" (EBinOp Plus (EVar "run_current") (EInt 1))]) Nothing
-          ]
+          [SVarAssign "iteration_current" (EBinOp Plus (EVar "iteration_current") (EInt 1))]
+            ++ (foldl' resetIterationVariablesFromInputs [] (systemInputs context))
+            ++ [ SIf
+                   (EBinOp Equal (EVar "iteration_current") (EVar "iteration_max"))
+                   ( SScope
+                       [ SVarAssign "iteration_current" (EInt 0),
+                         SVarAssign
+                           "run_current"
+                           (EBinOp Plus (EVar "run_current") (EInt 1))
+                       ]
+                   )
+                   Nothing
+               ]
+        where
+          resetIterationVariablesFromInputs acc x = SVarAssign ("i_" ++ show x) (EInt (0)) : acc
       scheduledRunsStmts = case ((inputType context), (runs context)) of
         (StdIn, _) -> []
         (Predefined, Perpetual) -> []
@@ -91,7 +102,18 @@ translateContextToMain context scheduleList =
         (StdIn, _) -> []
         (Predefined, Perpetual) -> []
         (Predefined, Limited x) -> [SVarDef TInt "run_current" (EInt (0)), SVarDef TInt "run_max" (EInt (x))]
-      mainInitStmts = mainInitInputStmts ++ mainInitRunsStmts ++ reverse (initBuffers context) ++ reverse (ioTokens context) ++ reverse (initDelay context)
+      mainInitIterStmts = case (inputType context) of
+        StdIn -> []
+        Predefined -> foldl' defineIterationVariablesFromInputs [] (systemInputs context)
+        where
+          defineIterationVariablesFromInputs acc x = SVarDef TInt ("i_" ++ show x) (EInt (0)) : acc
+      mainInitStmts =
+        mainInitInputStmts
+          ++ mainInitIterStmts
+          ++ mainInitRunsStmts
+          ++ reverse (initBuffers context)
+          ++ reverse (ioTokens context)
+          ++ reverse (initDelay context)
       mainFreeStmts = reverse (freeBuffers context) ++ [SReturn (Just (EInt 0))]
       mainBody = SScope (mainInitStmts ++ [whileStmt] ++ mainFreeStmts)
    in GFuncDef Nothing TInt "main" [] mainBody
@@ -219,7 +241,28 @@ translateIRConstructor initialContext constructor = case constructor of
                     (SVarDef TInt "i" (EInt 0))
                     (EBinOp Less (EVar "i") (EInt (bufferSize)))
                     (SExpr (EUnOp Increment (EVar "i")))
-                    (SScope [SExpr (ECall "write_token" [EVar $ show signalId, EArrayAccess (EVar ("input_" ++ show signalId)) (EBinOp Plus (EBinOp Multiply (EVar ("iteration_current")) (EInt bufferSize)) (EVar "i"))])])
+                    ( SScope
+                        ( [ SExpr
+                              ( ECall
+                                  "write_token"
+                                  [ EVar $ show signalId,
+                                    EArrayAccess
+                                      (EVar ("input_" ++ show signalId))
+                                      ( EBinOp
+                                          Plus
+                                          ( EBinOp
+                                              Multiply
+                                              (EVar ("iteration_current"))
+                                              (EInt (getScheduleBufferRate signalId (schedulerBufferList initialContext)))
+                                          )
+                                          (EVar ("i_" ++ show signalId))
+                                      )
+                                  ]
+                              )
+                          ]
+                            ++ [SVarAssign ("i_" ++ show signalId) (EBinOp Plus (EVar ("i_" ++ show signalId)) (EInt 1))]
+                        )
+                    )
              in (writeForStmt : acc)
         else
           if (elem signalId (systemOutputs initialContext))
@@ -276,6 +319,18 @@ getTargetRate context signalId =
    in case signal of
         Just (IRSignal _ _ (_, rate)) -> rate
         Nothing -> error ("getTargetRate - signal not found: " ++ show signalId)
+
+-- Get the rate from the schedule given an ActorId and bufferList
+getScheduleBufferRate :: IRId -> [(IRId, Int)] -> Int
+getScheduleBufferRate actorId bufferList =
+  case bufferList of
+    [] -> error ("buffer rate finder - actor not found: " ++ show actorId)
+    (x, rate) : xs ->
+      if (x == actorId)
+        then
+          rate
+        else
+          getScheduleBufferRate actorId xs
 
 translateIRFunctionToGlobals :: [IRConstructor] -> TranslationContext -> IRFunction -> TranslationContext
 translateIRFunctionToGlobals constructors currentContext function =


### PR DESCRIPTION
<del>Do not merge before #303</del>
#303 has been merged

# Description

Fixes things that are discussed at the end of #293. The result of how I implemented the indexing before was:

```C
while (1) {
        for (int i = 0; i < 2; i++) {
            write_token(s_in_a, input_s_in_a[iteration_current * 2 + i]);
        }
        actor12SDF(2, 2, 1, s_in_a, s_1, s_2, f_1);
        for (int i = 0; i < 2; i++) {
            write_token(s_in_a, input_s_in_a[iteration_current * 2 + i]);
        }
        actor12SDF(2, 2, 1, s_in_a, s_1, s_2, f_1);
        for (int i = 0; i < 1; i++) {
            write_token(s_in_b, input_s_in_b[iteration_current * 1 + i]);
        }
        actor13SDF(1, 2, 1, 2, s_in_b, s_3, s_4, s_5, f_2);
        for (int i = 0; i < 1; i++) {
            write_token(s_in_b, input_s_in_b[iteration_current * 1 + i]);
        }
```
since I expected that all inputs would be read at once. But this array flattening is wrong since the `* 2` and `i` variables for `s_in_a`, are wrong (should be `* 4` and then something that accumulates between loops). Now I implemented it with

```C
int main() {
    init();
    int iteration_current = 0;
    int i_s_in_b = 0;
    int i_s_in_a = 0;
    int run_current = 0;
    int run_max = 1;
// ...
    int output_s_out;
    while (1) {
        for (int i = 0; i < 2; i++) {
            write_token(s_in_a, input_s_in_a[iteration_current * 4 + i_s_in_a]);
            i_s_in_a = i_s_in_a + 1;
        }
        actor12SDF(2, 2, 1, s_in_a, s_1, s_2, f_1);
        for (int i = 0; i < 2; i++) {
            write_token(s_in_a, input_s_in_a[iteration_current * 4 + i_s_in_a]);
            i_s_in_a = i_s_in_a + 1;
        }
        actor12SDF(2, 2, 1, s_in_a, s_1, s_2, f_1);
        for (int i = 0; i < 1; i++) {
            write_token(s_in_b, input_s_in_b[iteration_current * 2 + i_s_in_b]);
            i_s_in_b = i_s_in_b + 1;
        }
        actor13SDF(1, 2, 1, 2, s_in_b, s_3, s_4, s_5, f_2);
        for (int i = 0; i < 1; i++) {
            write_token(s_in_b, input_s_in_b[iteration_current * 2 + i_s_in_b]);
            i_s_in_b = i_s_in_b + 1;
        }
        // ...
        i_s_in_b = 0;
        i_s_in_a = 0;
        if (iteration_current == iteration_max) {
            iteration_current = 0;
            run_current = run_current + 1;
        }
        if (run_current == run_max) {
            break;
        }
    }
    // ...
}
``` 

by passing the `bufferList` through the `translationContext` so that it can pull the total tokens on that input per period since that is how the buffer size is calculated in the schedule. I have not changed anything for how output works since I don't expect that to cause any problems?

(Also I need to update the documentation to include these variables and that we are not reading all of the inputs at once).

# Test

Try on SDF_example_008:
```
cabal run forsyde-compiler-exe -- ./examples/model/SDF_example_008.hs --input-type=predefined
```
with the following "input.h":
```c
int iteration_max = 4;

const token input_s_in_x[4] = {1,2,3,4};
const token input_s_in_y[4] = {1,2,3,4};
```
and check that the output of the model is like in the `simulation.md`:
```
2
6
12
20
```

Try for a model with inputs that run multiple times, like SDF_example_002:
```
cabal run forsyde-compiler-exe -- ./examples/model/SDF_example_002.hs --input-type=predefined
```
with the following "input.h":
```c
int iteration_max = 7;

token input_s_in_1[7*4] = {1, 1, 2, 4, 2, 2, 2, 2, 4, 1, 2, 1, 1, 1, 1, 1,
        0, 0, 0, 0, 0, 0, 0, 0, 1, 5, 2, 3};
token input_s_in_2[7] = {1, 2, 1, 1, 0, 0, 4};
```
and check that the output of the model is like in the `simulation.md`:
```
3 11
5 24
3 35
3 42
1 43
1 44
9 64
```