### PR TITLE
Allow delays connected to global inputs and outputs

### DIFF
--- a/examples/implementation/platform_independent/include/buffer_nonblocking.h
+++ b/examples/implementation/platform_independent/include/buffer_nonblocking.h
@@ -68,4 +68,9 @@ static void read_token(buffer_nonblocking *buf, token *data)
 	--buf->used;
 }
 
+static size_t contained_tokens(buffer_nonblocking *buf)
+{
+	return buf->used;
+}
+
 #endif

--- a/examples/model/SDF_example_020.hs
+++ b/examples/model/SDF_example_020.hs
@@ -1,0 +1,18 @@
+module SDF_example_020 where
+
+import ForSyDe.Shallow
+
+system :: Signal Int -> Signal Int
+system s_in = s_out
+  where
+    s_1 = a_delay1 s_in
+    s_out = a_add s_1
+
+a_delay1 :: Signal Int -> Signal Int
+a_delay1 s_in = delaySDF [0] s_in
+
+a_add :: Signal Int -> Signal Int
+a_add s_in = actor11SDF 1 1 f_add s_in
+
+f_add :: [Int] -> [Int]
+f_add [x] = [x + 1]

--- a/examples/model/SDF_example_021.hs
+++ b/examples/model/SDF_example_021.hs
@@ -1,0 +1,18 @@
+module SDF_example_021 where
+
+import ForSyDe.Shallow
+
+system :: Signal Int -> Signal Int
+system s_in = s_out
+  where
+    s_1 = a_add s_in
+    s_out = a_delay1 s_1
+
+a_delay1 :: Signal Int -> Signal Int
+a_delay1 s_in = delaySDF [0] s_in
+
+a_add :: Signal Int -> Signal Int
+a_add s_in = actor11SDF 1 1 f_add s_in
+
+f_add :: [Int] -> [Int]
+f_add [x] = [x + 1]

--- a/examples/model/SDF_example_022.hs
+++ b/examples/model/SDF_example_022.hs
@@ -1,0 +1,32 @@
+module SDF_example_022 where
+
+import ForSyDe.Shallow
+
+-- Netlist
+system :: Signal Int
+system = s_out
+  where
+    (first, second) = a_a first_delayed1 second_delayed
+    first_delayed = d_1 first
+    (first_delayed1, s_out) = a_split first_delayed
+    second_delayed = d_2 second
+
+-- Process specifications
+a_a :: Signal Int -> Signal Int -> (Signal Int, Signal Int)
+a_a s_1 s_2 = actor22SDF (1, 1) (1, 1) fib s_1 s_2
+
+a_split :: Signal Int -> (Signal Int, Signal Int)
+a_split s_1 = actor12SDF 1 (1, 1) f_split s_1
+
+d_1 :: Signal Int -> Signal Int
+d_1 s = delaySDF [0] s
+
+d_2 :: Signal Int -> Signal Int
+d_2 s = delaySDF [1] s
+
+-- Function definitions
+fib :: [Int] -> [Int] -> ([Int], [Int])
+fib [first] [second] = ([second], [first + second])
+
+f_split :: [Int] -> ([Int], [Int])
+f_split [x] = ([x], [x])

--- a/examples/model/SDF_example_023.hs
+++ b/examples/model/SDF_example_023.hs
@@ -1,0 +1,19 @@
+module SDF_example_023 where
+
+import ForSyDe.Shallow
+
+system s_in = s_out
+  where
+    s_out = actor_base64 s_in
+
+actor_base64 :: Signal Int -> Signal Int
+actor_base64 s_in = actor11SDF 3 4 f_base64 s_in
+
+-- Intentionally avoid bitwise operations
+f_base64 :: [Int] -> [Int]
+f_base64 [a0, a1, a2] =
+  [ a0 `div` 4,
+    a0 * 16 - (a0 `div` 4) * 64 + a1 `div` 16,
+    a1 * 4 - (a1 `div` 16) * 64 + a2 `div` 64,
+    a2 - (a2 `div` 64) * 64
+  ]

--- a/examples/model/SDF_example_024.hs
+++ b/examples/model/SDF_example_024.hs
@@ -1,0 +1,59 @@
+module SDF_example_024 where
+
+import ForSyDe.Shallow
+
+system :: Signal Int -> (Signal Int, Signal Int, Signal Int)
+system s_in = (s_full, s_partial3, s_partial2)
+  where
+    (s_in1, s_in2, s_in3) = actor_3split s_in
+    s_pre_partial3_delayed = delay_partial_3 s_in2
+    s_partial3 = actor_base64_partial_3 s_pre_partial3_delayed
+    s_pre_partial2_delayed = delay_partial_2 s_in3
+    s_partial2 = actor_base64_partial_2 s_pre_partial2_delayed
+    s_full = actor_base64 s_in1
+
+actor_base64 :: Signal Int -> Signal Int
+actor_base64 s_in = actor11SDF 3 4 f_base64 s_in
+
+actor_base64_partial_3 :: Signal Int -> Signal Int
+actor_base64_partial_3 s_in = actor11SDF 3 4 f_base64_partial_3 s_in
+
+actor_base64_partial_2 :: Signal Int -> Signal Int
+actor_base64_partial_2 s_in = actor11SDF 3 4 f_base64_partial_2 s_in
+
+actor_3split :: Signal Int -> (Signal Int, Signal Int, Signal Int)
+actor_3split s_in = actor13SDF 1 (1, 1, 1) f_3split s_in
+
+delay_partial_3 :: Signal Int -> Signal Int
+delay_partial_3 s_in = delaySDF [0] s_in
+
+delay_partial_2 :: Signal Int -> Signal Int
+delay_partial_2 s_in = delaySDF [0, 0] s_in
+
+f_3split :: [Int] -> ([Int], [Int], [Int])
+f_3split [x] = ([x], [x], [x])
+
+-- Intentionally avoid bitwise operations
+f_base64 :: [Int] -> [Int]
+f_base64 [a0, a1, a2] =
+  [ a0 `div` 4,
+    a0 * 16 - (a0 `div` 4) * 64 + a1 `div` 16,
+    a1 * 4 - (a1 `div` 16) * 64 + a2 `div` 64,
+    a2 - (a2 `div` 64) * 64
+  ]
+
+f_base64_partial_3 :: [Int] -> [Int]
+f_base64_partial_3 [_, a0, a1] =
+  [ a0 `div` 4,
+    a0 * 16 - (a0 `div` 4) * 64 + a1 `div` 16,
+    a1 * 4 - (a1 `div` 16) * 64,
+    -1
+  ]
+
+f_base64_partial_2 :: [Int] -> [Int]
+f_base64_partial_2 [_, _, a0] =
+  [ a0 `div` 4,
+    a0 * 16 - (a0 `div` 4) * 64,
+    -1,
+    -1
+  ]

--- a/examples/model/SDF_example_025.hs
+++ b/examples/model/SDF_example_025.hs
@@ -1,0 +1,29 @@
+module SDF_example_025 where
+
+import ForSyDe.Shallow
+
+-- Netlist
+system :: Signal Int -> Signal Int
+system s_in = s_out
+  where
+    (s_out_pre, first, second) = a_a s_in first_delayed second_delayed
+    first_delayed = d_1 first
+    second_delayed = d_2 second
+    s_out = d_out s_out_pre
+
+-- Process specifications
+a_a :: Signal Int -> Signal Int -> Signal Int -> (Signal Int, Signal Int, Signal Int)
+a_a s_1 s_2 s_3 = actor33SDF (1, 1, 1) (1, 1, 1) fib s_1 s_2 s_3
+
+d_1 :: Signal Int -> Signal Int
+d_1 s = delaySDF [0] s
+
+d_2 :: Signal Int -> Signal Int
+d_2 s = delaySDF [1] s
+
+d_out :: Signal Int -> Signal Int
+d_out s = delaySDF [0, 1] s
+
+-- Function definitions
+fib :: [Int] -> [Int] -> [Int] -> ([Int], [Int], [Int])
+fib [index] [first] [second] = ([index + first + second], [second], [index + first + second])

--- a/examples/model/SDF_example_026.hs
+++ b/examples/model/SDF_example_026.hs
@@ -1,0 +1,56 @@
+module SDF_example_026 where
+
+import ForSyDe.Shallow
+
+-- Netlist
+system :: Signal Int -> Signal Int
+system s_in = s_out
+  where
+    (s_1, s_2) = a_1 s_in s_5_delayed
+    s_3 = a_2 s_1
+    s_4 = a_3 s_2
+    (s_out, s_5) = a_4 s_3 s_4
+    s_5_delayed = d_1 s_5
+
+-- Process specifications
+a_1 :: Signal Int -> Signal Int -> (Signal Int, Signal Int)
+a_1 s_1 s_2 = actor22SDF (2, 1) (2, 1) f_1 s_1 s_2
+
+a_2 :: Signal Int -> Signal Int
+a_2 s_1 = actor11SDF 2 2 f_2 s_1
+
+a_3 :: Signal Int -> Signal Int
+a_3 s_1 = actor11SDF 1 1 f_3 s_1
+
+a_4 :: Signal Int -> Signal Int -> (Signal Int, Signal Int)
+a_4 s_1 s_2 = actor22SDF (2, 1) (1, 1) f_4 s_1 s_2
+
+d_1 :: Signal Int -> Signal Int
+d_1 s_1 = delaySDF [0] s_1
+
+-- Function definitions
+f_1 :: [Int] -> [Int] -> ([Int], [Int])
+f_1 [x1, x2] [y] = ([x1, x2], [y])
+
+f_2 :: [Int] -> [Int]
+f_2 [x, y] = [x + 1, y + 1]
+
+f_3 :: [Int] -> [Int]
+f_3 [x] = [x + 1]
+
+f_4 :: [Int] -> [Int] -> ([Int], [Int])
+f_4 [x1, x2] [y] = ([(x1 + x2) * 2 - (x1 + x2) + y], [y])
+
+-- Error messages
+
+-- * Eta reduce seems not to be allowed
+
+--  ==> Error message:
+--   forsyde-compiler-exe: createSignalsFromArguments - No rates found
+--   for process constructor: a_2
+
+-- * PASS does not exist
+
+--  ==> Error message:
+--   forsyde-compiler-exe: Matrix rank is not equal to number of actors
+--   minus one. Cannot compute repetition vector.

--- a/examples/model/SDF_example_027.hs
+++ b/examples/model/SDF_example_027.hs
@@ -1,0 +1,43 @@
+module SDF_example_027 where
+
+import ForSyDe.Shallow
+
+-- System Netlist
+system s_in = s_out
+  where
+    s_1 = p_1 s_in s_6_delayed
+    (s_2, s_3) = p_2 s_1
+    s_6 = p_3 s_3 s_5
+    (s_out, s_4) = p_4 s_2
+    s_5 = p_5 s_4
+    s_6_delayed = delaySDF [0, 0] s_6
+
+-- Process Specification
+p_1 = actor21SDF (2, 1) 1 f_1
+  where
+    f_1 [x1, x2] [y] = [x1 + x2 + y]
+
+p_2 = actor12SDF 1 (1, 1) f_2
+  where
+    f_2 [x] = ([x], [x + 1])
+
+p_3 = actor21SDF (2, 2) 2 f_3
+  where
+    f_3 [x1, x2] [y1, y2] = [x1 + x2, y1 + y2]
+
+p_4 = actor12SDF 1 (3, 1) f_4
+  where
+    f_4 [x] = ([x, x + 1, x + 2], [x])
+
+p_5 = actor11SDF 1 1 f_5
+  where
+    f_5 [x] = [x + 1]
+
+-- Test Input
+s_in = signal [1 .. 10]
+
+-- Expected output
+
+-- * SDF_System_Model>  system s_in
+
+-- {3,4,5,7,8,9,23,24,25,27,28,29,71,72,73}

--- a/src/CoreIRToProceduralIR.hs
+++ b/src/CoreIRToProceduralIR.hs
@@ -223,14 +223,6 @@ translateFunctionContent context contentList =
     stackToScope acc (outputSignal, exprList) =
       let outputStmts = map (\(idx, expr) -> SArrayAssign outputSignal (EInt idx) Nothing expr) (zip [0 ..] exprList)
        in (acc ++ outputStmts)
-    -- Helper function which wraps Procedural IR expression which use non
-    -- commutative binary or unary operators in parenthesis.
-    wrapNonCommutativeExpression :: Expression -> Expression
-    wrapNonCommutativeExpression e = case e of
-      EBinOp Minus _ _ -> EParen e
-      EBinOp Divide _ _ -> EParen e
-      EUnOp Negate _ -> EParen e
-      _ -> e
     -- Helper function to handle the case when the `FunctionContent` represents
     -- a `BinaryOperator`
     binOpContentToStack :: BinaryOperator -> Stack [Expression] -> Stack [Expression]
@@ -239,7 +231,7 @@ translateFunctionContent context contentList =
             Nothing -> error "translateFunctionContent - empty expression stack when popping"
             Just (elist, stack1) -> (elist, stack1)
           (expr1, expr2, exprTail) = case exprList of
-            (e1 : e2 : eTail) -> (wrapNonCommutativeExpression e1, wrapNonCommutativeExpression e2, eTail)
+            (e1 : e2 : eTail) -> (EParen e1, EParen e2, eTail)
             _ -> error ("translateFunctionContent - insufficient operands for " ++ show binOp)
           newExpr = EBinOp binOp expr1 expr2
           newExprList = newExpr : exprTail
@@ -280,7 +272,7 @@ translateFunctionContent context contentList =
               Nothing -> error "translateFunctionContent - empty expression stack when popping"
               Just (elist, stack1) -> (elist, stack1)
             (expr1, exprTail) = case exprList of
-              (e1 : eTail) -> (e1, eTail)
+              (e1 : eTail) -> (EParen e1, eTail)
               _ -> error "translateFunctionContent - insufficient operands for Negate"
             newExpr = EUnOp Negate expr1
             newExprList = newExpr : exprTail

--- a/src/ForSyDeIRToProceduralIR.hs
+++ b/src/ForSyDeIRToProceduralIR.hs
@@ -1,11 +1,9 @@
 module ForSyDeIRToProceduralIR where
 
 import ArgumentsMain (InputType (Predefined, StdIn), Runs (Limited, Perpetual))
-import CoreIR (literalToInt, prettyCoreExpr, varToString)
 import CoreIRToProceduralIR (translateIRFunction)
 import ForSyDeIR
 import GHC hiding (targetId)
-import GHC.Core
 import ProceduralIR
 
 -- | The `TranslationContext` is a data type which is used to pass around
@@ -338,48 +336,3 @@ translateIRFunctionToGlobals constructors currentContext function =
         (functionDeclaration, Just functionDefinition) -> currentContext {initFunctions = functionDeclaration : (initFunctions currentContext), functions = functionDefinition : (functions currentContext)}
         (functionDeclaration, Nothing) -> currentContext {initFunctions = functionDeclaration : (initFunctions currentContext)}
    in context1
-
--- The following is a temporary hard coded solution that translates the inputs
--- of the `add` and `accummulate` functions from SDF example 8.
-translateCoreExprToGlobals :: TranslationContext -> IRId -> CoreExpr -> (Global, Global)
-translateCoreExprToGlobals context binder expr = case (binder, expr) of
-  (b, Lam _ (Lam _ e))
-    | b == IRString "accumulate" ->
-        let functionScopeStmt = translateCoreExprToStatement context e
-            initFunctionGlobal = GFuncDeclare (Just Static) TVoid (show binder) [(TPointer TInt, "input_1"), (TPointer TInt, "input_2"), (TPointer TInt, "output_1"), (TPointer TInt, "output_2")]
-            functionGlobal = GFuncDef (Just Static) TVoid (show binder) [(TPointer TInt, "input_1"), (TPointer TInt, "input_2"), (TPointer TInt, "output_1"), (TPointer TInt, "output_2")] functionScopeStmt
-         in (initFunctionGlobal, functionGlobal)
-  (b, Lam _ (Lam _ e))
-    | b == IRString "add" ->
-        let functionScopeStmt = translateCoreExprToStatement context e
-            initFunctionGlobal = GFuncDeclare (Just Static) TVoid (show binder) [(TPointer TInt, "input_1"), (TPointer TInt, "input_2"), (TPointer TInt, "output")]
-            functionGlobal = GFuncDef (Just Static) TVoid (show binder) [(TPointer TInt, "input_1"), (TPointer TInt, "input_2"), (TPointer TInt, "output")] functionScopeStmt
-         in (initFunctionGlobal, functionGlobal)
-  _ -> error ("translateCoreExprToGlobals - unsupported expression:\n" ++ prettyCoreExpr (flags context) expr)
-
--- The following is a temporary hard coded solution that translates the
--- contents and outputs of the `add` and `accumulate` functions from SDF
--- example 8.
-translateCoreExprToStatement :: TranslationContext -> CoreExpr -> Statement
-translateCoreExprToStatement context expr = case expr of
-  Var varId -> SExpr (EVar (varToString varId))
-  Lit i -> SExpr (EInt (literalToInt i))
-  App (App (App (Var _) (Type _)) (App (App (App (App (Var _op1) (Type _)) (Var _)) (Var _a1)) (Var _a2))) (App (Var _) (Type _)) ->
-    let stmt = SArrayAssign "output" (EInt 0) Nothing (EBinOp Plus (EArrayAccess (EVar "input_1") (EInt 0)) (EArrayAccess (EVar "input_2") (EInt 0)))
-     in SScope ([stmt])
-  App (App (App (App (Var _) (Type _)) (Type _)) (App (App (App (Var _) (Type _)) (App (App (App (App (Var _op1) (Type _)) (Var _)) (Var _a1)) (Var _a2))) (App (Var _) (Type _)))) (App (App (App (Var _) (Type _)) (App (App (App (App (Var _op2) (Type _)) (Var _)) (Var _b1)) (Var _b2))) (App (Var _) (Type _))) ->
-    let stmt1 = SArrayAssign "output_1" (EInt 0) Nothing (EBinOp Plus (EArrayAccess (EVar "input_1") (EInt 0)) (EArrayAccess (EVar "input_2") (EInt 0)))
-        stmt2 = SArrayAssign "output_2" (EInt 0) Nothing (EBinOp Plus (EArrayAccess (EVar "input_1") (EInt 0)) (EArrayAccess (EVar "input_2") (EInt 0)))
-     in SScope ([stmt1, stmt2])
-  Let _ e -> translateCoreExprToStatement context e
-  Case _ _ _ alts -> translateAltsToStatements context alts
-  Lam _ e -> translateCoreExprToStatement context e
-  App _ e -> translateCoreExprToStatement context e
-  Tick _ e -> translateCoreExprToStatement context e
-  _ -> error ("translateCoreExprToStatement - unsupported expression:\n" ++ prettyCoreExpr (flags context) expr)
-
-translateAltsToStatements :: TranslationContext -> [Alt CoreBndr] -> Statement
-translateAltsToStatements context alts = case alts of
-  [] -> error ""
-  (Alt (DataAlt _) _ e) : [] -> translateCoreExprToStatement context e
-  _ : altsTail -> translateAltsToStatements context altsTail

--- a/src/ForSyDeIRToProceduralIR.hs
+++ b/src/ForSyDeIRToProceduralIR.hs
@@ -169,7 +169,11 @@ translateIRConstructor initialContext constructor = case constructor of
           Just bufferId ->
             let foldDelayTokens :: [Statement] -> Int -> [Statement]
                 foldDelayTokens acc token =
-                  let stmt = SExpr (ECall "write_token" [EVar $ show bufferId, EInt token])
+                  let stmt =
+                        if elem bufferId (systemOutputs initialContext)
+                          -- TODO: Match the output with the actor on the signal
+                          then SExpr (ECall "printf" [EString "%d\n", EInt token])
+                          else SExpr (ECall "write_token" [EVar $ show bufferId, EInt token])
                    in (stmt : acc)
                 delayStmts = (foldl' foldDelayTokens [] tokens)
              in initialContext {initDelay = delayStmts ++ initDelay initialContext}
@@ -193,8 +197,8 @@ translateIRConstructor initialContext constructor = case constructor of
                     ++ [EVar $ show functionId]
                 )
             )
-        inputStmts = foldl' foldActorSignals [] inputSignals
-        outputStmts = foldl' foldActorSignals [] outputSignals
+        inputStmts = foldl' foldActorSignals [] translatedInputSignals
+        outputStmts = foldl' foldActorSignals [] translatedOutputSignals
         stmts = reverse inputStmts ++ [actorCallStmt] ++ reverse outputStmts
         context1 = initialContext {actors = (actorId, stmts) : actors initialContext}
      in context1
@@ -219,7 +223,7 @@ translateIRConstructor initialContext constructor = case constructor of
                 -- standard in.
                 scanForStmt =
                   SFor
-                    (SVarDef TInt "i" (EInt 0))
+                    (SVarDef TInt "i" (ECall "contained_tokens" [EVar $ show signalId]))
                     (EBinOp Less (EVar "i") (EInt (bufferSize)))
                     (SExpr (EUnOp Increment (EVar "i")))
                     (SScope [SVarAssign "status" (ECall "scanf" [EString "%d", EReference (EArrayAccess (EVar ("input_" ++ show signalId)) (EVar "i"))])])
@@ -236,7 +240,7 @@ translateIRConstructor initialContext constructor = case constructor of
             let bufferSize = getTargetRate initialContext signalId
                 writeForStmt =
                   SFor
-                    (SVarDef TInt "i" (EInt 0))
+                    (SVarDef TInt "i" (ECall "contained_tokens" [EVar $ show signalId]))
                     (EBinOp Less (EVar "i") (EInt (bufferSize)))
                     (SExpr (EUnOp Increment (EVar "i")))
                     ( SScope

--- a/src/SDFSchedule.hs
+++ b/src/SDFSchedule.hs
@@ -85,14 +85,16 @@ convertIRSystem (IRSystem (inputNames, outputNames) constructors signals _) =
          in case (incoming, outgoing) of
               ([(inSignalId, srcIn, prodIn)], [(outSignalId, dstOut, consOut)]) ->
                 [ Edge
-                    (IRString $ show inSignalId ++ "_" ++ show outSignalId) -- delay edge names are combined
+                    -- use the input signal id as the delay edge id
+                    inSignalId
                     (findActorByName srcIn)
                     (findActorByName dstOut)
                     prodIn
                     consOut
                     True
                     (length delayConstructor)
-                    (Just [(inSignalId, IRString $ show inSignalId ++ "_" ++ show outSignalId), (outSignalId, IRString $ show inSignalId ++ "_" ++ show outSignalId)])
+                    -- allow the edge to be found by the output signal id as well
+                    (Just [(outSignalId, inSignalId)])
                 ]
               ([], _) ->
                 error $ "Delay node " ++ show delayName ++ " has no input signal."

--- a/src/SDFSchedule.hs
+++ b/src/SDFSchedule.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
 
 module SDFSchedule (computeScheduleAndBuffers, computeScheduleAndBuffersPrint) where
 
@@ -97,8 +98,9 @@ convertIRSystem (IRSystem (inputNames, outputNames) constructors signals _) =
                     consOut
                     True
                     (length delayConstructor)
-                    -- allow the edge to be found by the output signal id as well
-                    (Just [(outSignalId, inSignalId)])
+                    -- allow the edge to be found by the output signal id as well.
+                    -- Note that we need the in->in as we only lookup the aliaes.
+                    (Just [(inSignalId, inSignalId), (outSignalId, inSignalId)])
                 ]
               ([], _) ->
                 error $ "Delay node " ++ show delayName ++ " has no input signal."
@@ -407,21 +409,63 @@ simulateBufferUsage actors edges initialTokens schedule =
       let production = prod (edges !! edgeIdx)
        in updateAt edgeIdx (+ production) tokens
 
-computeIOBufferSizes :: IRSystem -> [(IRId, Int)] -> [(IRId, Int)]
-computeIOBufferSizes (IRSystem (inputs, outputs) _ signals _) repsWithNames =
+computeIOBufferSizes :: IRSystem -> [(IRId, Int)] -> ([(IRId, Int)], [(IRId, IRId)])
+computeIOBufferSizes (IRSystem (inputs, outputs) constructors signals _) repsWithNames =
   let -- Find all external input edges
       inputEdges =
-        [ (signalId, dstRate, findActorRep dstId)
-        | IRSignal signalId (srcId, _) (dstId, dstRate) <- signals,
+        [ (signalId, dstRate, findActorRep dstId, aliases, nTokens)
+        | (IRSignal signalId (srcId, _) (dstId, dstRate), aliases, nTokens) <- map nonDelayInputSignal inputSignals,
+          srcId `elem` inputs
+        ]
+      inputSignals =
+        [ s
+        | s@(IRSignal _ (srcId, _) (_, _)) <- signals,
           srcId `elem` inputs
         ]
 
+      -- Find the first non-delay process connected to the input signal
+      nonDelayInputSignal s@(IRSignal sigId (srcId, srcRate) (dstId, _)) =
+        case find (\c -> constructorName c == dstId) constructors of
+          -- The signal directly connects to an actor
+          Just (IRActor _ _ _ _) -> (s, [], 0)
+          -- The signal connects to a delay, keep going
+          Just (IRDelay dName tokens (_, next)) | dstId == dName ->
+            case find (\(IRSignal sId _ _) -> sId == next) signals of
+              Just (IRSignal sigAlias (_, _) (newDstId, newDstRate)) ->
+                let (sig, aliases, nTokens) = nonDelayInputSignal (IRSignal sigId (srcId, srcRate) (newDstId, newDstRate))
+                 in (sig, (sigId, sigId) : (sigAlias, sigId) : aliases, nTokens + length tokens)
+              Nothing -> error $ "Could not find next signal " ++ show next
+          _ -> error $ "Could not find the process " ++ show srcId
+
       -- Find all external output edges
       outputEdges =
-        [ (signalId, srcRate, findActorRep srcId)
-        | IRSignal signalId (srcId, srcRate) (dstId, _) <- signals,
+        [ (signalId, srcRate, findActorRep srcId, aliases, nTokens)
+        | (IRSignal signalId (srcId, srcRate) (dstId, _), aliases, nTokens) <- map nonDelayOutputSignal outputSignals,
           dstId `elem` outputs
         ]
+      outputSignals =
+        [ s
+        | s@(IRSignal _ (_, _) (dstId, _)) <- signals,
+          dstId `elem` outputs
+        ]
+
+      -- Find the first non-delay process connected to the output signal
+      nonDelayOutputSignal s@(IRSignal sigId (srcId, _) (dstId, dstRate)) =
+        case find (\c -> constructorName c == srcId) constructors of
+          -- The signal directly connects to an actor
+          Just (IRActor _ _ _ _) -> (s, [], 0)
+          -- The signal connects to a delay, keep going
+          Just (IRDelay dName tokens (next, _)) | srcId == dName ->
+            case find (\(IRSignal sId _ _) -> sId == next) signals of
+              Just (IRSignal sigAlias (newSrcId, newSrcRate) (_, _)) ->
+                let (sig, aliases, nTokens) = nonDelayOutputSignal (IRSignal sigId (newSrcId, newSrcRate) (dstId, dstRate))
+                 in (sig, (sigId, sigId) : (sigAlias, sigId) : aliases, nTokens + length tokens)
+              Nothing -> error $ "Could not find next signal " ++ show next
+          _ -> error $ "Could not find the process " ++ show srcId
+
+      constructorName = \case
+        IRActor cName _ _ _ -> cName
+        IRDelay cName _ _ -> cName
 
       -- Find repetition count by actor names
       findActorRep actorName =
@@ -429,18 +473,10 @@ computeIOBufferSizes (IRSystem (inputs, outputs) _ signals _) repsWithNames =
           Just rep -> rep
           Nothing -> error $ "Actor " ++ show actorName ++ " not found in repetition counts"
 
-      -- Calculate input buffer size：rate × dst actor rep count
-      inputBuffers =
-        [ (signalId, dstRate * rep)
-        | (signalId, dstRate, rep) <- inputEdges
-        ]
-
-      -- Calculate output buffer size：rate × src actor rep count
-      outputBuffers =
-        [ (signalId, srcRate * rep)
-        | (signalId, srcRate, rep) <- outputEdges
-        ]
-   in inputBuffers ++ outputBuffers
+      -- separate the buffers and aliases
+      foldBuffer (sigId, rate, rep, aliases, nTokens) (sigAcc, aliasAcc) =
+        ((sigId, max (rate * rep) nTokens) : sigAcc, aliases ++ aliasAcc)
+   in foldr foldBuffer ([], []) $ inputEdges ++ outputEdges
 
 ----------------------------------------------------------
 -- Verification of the schedule
@@ -485,8 +521,8 @@ computeScheduleAndBuffers irSystem =
           let schedNames = map name actors
               repsWithNames = zip (map name actors) (replicate (length actors) 1)
               internalBufSizes = zip (map edgeName edges) (replicate (length edges) 0)
-              ioBufSizes = computeIOBufferSizes irSystem repsWithNames
-           in (schedNames, ioBufSizes ++ internalBufSizes, [])
+              (ioBufSizes, aliases) = computeIOBufferSizes irSystem repsWithNames
+           in (schedNames, ioBufSizes ++ internalBufSizes, aliases)
         else
           let mat = buildTopologyMatrixEdgesRows actors edges
               rankMat = rank mat
@@ -510,9 +546,9 @@ computeScheduleAndBuffers irSystem =
                                 schedIdxs = greedySchedule actors edges repCounts
                                 schedNames = map (name . (actors !!)) schedIdxs
                                 internalBufSizes = simulateBufferUsage actors edges (map initTokens edges) schedIdxs
-                                ioBufSizes = computeIOBufferSizes irSystem repsWithNames
+                                (ioBufSizes, aliases) = computeIOBufferSizes irSystem repsWithNames
                                 delayBuffers = getBuffers edges
-                             in (schedNames, ioBufSizes ++ internalBufSizes, delayBuffers)
+                             in (schedNames, ioBufSizes ++ internalBufSizes, delayBuffers ++ aliases)
                    in finalResult
                 else
                   error "Matrix rank is not equal to number of actors minus one. Cannot compute repetition vector."
@@ -543,7 +579,7 @@ computeScheduleAndBuffersPrint irSystem =
                     repsWithNames = zip (map name actors) (replicate (length actors) 1)
                     internalBufSizes = zip (map edgeName edges) (replicate (length edges) 0)
                     ioBufSizes = computeIOBufferSizes irSystem repsWithNames
-                    allBufSizes = ioBufSizes ++ internalBufSizes
+                    allBufSizes = fst ioBufSizes ++ internalBufSizes
                  in "No internal edges found.\n\n"
                       ++ "Schedule (all actors fire once):\n"
                       ++ intercalate ", " (map show schedNames)
@@ -616,7 +652,7 @@ computeScheduleAndBuffersPrint irSystem =
                             -- Simulate buffer usage for one period
                             internalBufSizes = simulateBufferUsage actors edges (map initTokens edges) schedIdxs
                             ioBufSizes = computeIOBufferSizes irSystem repsWithNames
-                            allBufSizes = ioBufSizes ++ internalBufSizes
+                            allBufSizes = fst ioBufSizes ++ internalBufSizes
 
                             internalBufStr =
                               "\n\nInternal buffer sizes (maximum tokens observed per edge):"
@@ -628,7 +664,7 @@ computeScheduleAndBuffersPrint irSystem =
                               "\n\nI/O buffer sizes (rate × repetition count):"
                                 ++ concatMap
                                   (\(ename, sz) -> "\n  " ++ show ename ++ ": " ++ show sz)
-                                  ioBufSizes
+                                  (fst ioBufSizes)
 
                             allBufStr =
                               "\n\nAll buffer sizes (I/O + internal):"

--- a/src/SDFSchedule.hs
+++ b/src/SDFSchedule.hs
@@ -83,6 +83,10 @@ convertIRSystem (IRSystem (inputNames, outputNames) constructors signals _) =
                 srcId == delayName
               ]
          in case (incoming, outgoing) of
+              -- input is a global system input -> ignore
+              ([(inSignalId, _, _)], _) | inSignalId `elem` inputNames -> []
+              -- output is a global system output -> ignore
+              (_, [(outSignalId, _, _)]) | outSignalId `elem` outputNames -> []
               ([(inSignalId, srcIn, prodIn)], [(outSignalId, dstOut, consOut)]) ->
                 [ Edge
                     -- use the input signal id as the delay edge id

--- a/test/SDFScheduleSpec.hs
+++ b/test/SDFScheduleSpec.hs
@@ -126,7 +126,7 @@ spec = do
     it "exampleSystem1: System with single actor and self loop" $ do
       let (actualSchedule, actualBuffers, _) = computeScheduleAndBuffers exampleSystem1
       let expectedSchedule = [IRString "actor_1"]
-      let expectedBuffers = [(IRString "s_in", 1), (IRString "s_out", 1), (IRString "s_1_s_2", 1)]
+      let expectedBuffers = [(IRString "s_in", 1), (IRString "s_out", 1), (IRString "s_1", 1)]
       (actualSchedule, actualBuffers) `shouldBe` (expectedSchedule, expectedBuffers)
 
     it "exampleSystem2: System with single actor and nothing else" $ do
@@ -138,23 +138,23 @@ spec = do
     it "exampleSystem3: System with two actors, one self loop" $ do
       let (actualSchedule, actualBuffers, _) = computeScheduleAndBuffers exampleSystem3
       let expectedSchedule = [IRString "actor_1", IRString "actor_2"]
-      let expectedBuffers = [(IRString "s_in", 1), (IRString "s_out", 1), (IRString "s_3", 1), (IRString "s_1_s_2", 1)]
+      let expectedBuffers = [(IRString "s_in", 1), (IRString "s_out", 1), (IRString "s_3", 1), (IRString "s_1", 1)]
       (actualSchedule, actualBuffers) `shouldBe` (expectedSchedule, expectedBuffers)
 
     it "exampleSystem4: System with multiple inputs" $ do
       let (actualSchedule, actualBuffers, _) = computeScheduleAndBuffers exampleSystem4
       let expectedSchedule = [IRString "actor_a", IRString "actor_a", IRString "actor_b", IRString "actor_c", IRString "actor_d"]
-      let expectedBuffers = [(IRString "s_ina", 4), (IRString "s_inb", 1), (IRString "s_out", 2), (IRString "s_1", 2), (IRString "s_2", 2), (IRString "s_3", 1), (IRString "s_4_delay_s_4", 1)]
+      let expectedBuffers = [(IRString "s_ina", 4), (IRString "s_inb", 1), (IRString "s_out", 2), (IRString "s_1", 2), (IRString "s_2", 2), (IRString "s_3", 1), (IRString "s_4_delay", 1)]
       (actualSchedule, actualBuffers) `shouldBe` (expectedSchedule, expectedBuffers)
 
     it "exampleSystem5" $ do
       let (actualSchedule, actualBuffers, _) = computeScheduleAndBuffers exampleSystem5
       let expectedSchedule = [IRString "a", IRString "a", IRString "b", IRString "c", IRString "c", IRString "c"]
-      let expectedBuffers = [(IRString "s_in", 4), (IRString "s_out", 3), (IRString "s1", 2), (IRString "s2", 3), (IRString "s3_delay_s3", 6)]
+      let expectedBuffers = [(IRString "s_in", 4), (IRString "s_out", 3), (IRString "s1", 2), (IRString "s2", 3), (IRString "s3_delay", 6)]
       (actualSchedule, actualBuffers) `shouldBe` (expectedSchedule, expectedBuffers)
 
     it "exampleSystem6" $ do
       let (actualSchedule, actualBuffers, _) = computeScheduleAndBuffers exampleSystem6
       let expectedSchedule = [IRString "d", IRString "c", IRString "a", IRString "a", IRString "c", IRString "a", IRString "a", IRString "b", IRString "c", IRString "a", IRString "a", IRString "c", IRString "a", IRString "a", IRString "b"]
-      let expectedBuffers = [(IRString "s_in", 16), (IRString "s_out", 1), (IRString "s1", 4), (IRString "s3", 4), (IRString "s4", 4), (IRString "s2_delay_s2", 2)]
+      let expectedBuffers = [(IRString "s_in", 16), (IRString "s_out", 1), (IRString "s1", 4), (IRString "s3", 4), (IRString "s4", 4), (IRString "s2_delay", 2)]
       (actualSchedule, actualBuffers) `shouldBe` (expectedSchedule, expectedBuffers)


### PR DESCRIPTION
Allow delays to be connected to global inputs and outputs.

There are a few parts of this:
1. SDFSchedule needs to find the correct rate when the IO edge is a delay. Do that by finding the first actor along that signal chain and use that rate.
2. This also does not generate a new IRId for delay edges and just uses the input one. Note that we still need the alias for the input signal since we always do the lookup.
3. ForSyDeIRToProceduralIR needs to use the translated buffers for `foldActorSignals` so it can see the actual buffer id.
4. Add examples for these scenarios.
5. Also remove the old hardcoded first attempt at translating Core functions to ProceduralIR.