### PR TITLE
WIP: attempt to place less parentheses

### DIFF
--- a/docs/procedural-ir.md
+++ b/docs/procedural-ir.md
@@ -15,7 +15,6 @@ Additionally, the procedural IR serves as an intermediate representation when co
 
 - These language elements are intentionally excluded from the current IR stage to maintain focus on the core model semantics.
 
-
 ## Key Components
 
 ### 1. StorageClass and TypeQualifier
@@ -64,8 +63,10 @@ data BinaryOperator
   | GreaterEqual -- lhs >= rhs
 ```
 
-Procedural IR does not contain information about the associativity and precedence of operators. Specifically, unary operators are currently all treated the same way and placed at the left of the expression. This is currently fine since `++i` works in loop, but use with care if using this grammar in array access. 
-
+Operators implement the type class `Operator`, which has functions for
+associativity and precedence according to the `operator(7)` manual page. This
+is used in the pretty-printing to C for adding `EParen` around expressions
+which would be parsed the wrong way otherwise.
 
 ### 3. Types (`Type`)
 ```Haskell
@@ -111,8 +112,7 @@ data Expression
   | EParen Expression -- (expr)
 ```
 
-Expressions can be considered as values, including literals, variables and its references and pointers, arithmetic, and function calls. 
-
+Expressions can be considered as values, including literals, variables and its references and pointers, arithmetic, and function calls.
 
 ### 5. Statements (`Statement`)
 ```Haskell
@@ -135,7 +135,6 @@ data Statement
   | SLabel String
 ```
 Statements are the main building blocks of procedural program with assignments, control flow.
-
 
 ### 6. Globals
 ```Haskell
@@ -164,19 +163,16 @@ A complete Procedural IR program is a list of Global (functions).
 - If a function takes an array as parameter, it can only be represented by `int *x`, not `int x[]`, since currently function parameters are only represented as `Type Name`.
 - Due to the reason above, multi-dimensional arrays as parameters (e.g., `int x[][4]`) are not handled. Only dynamically allocated arrays could be used and pass them as `int**`. If this is a necessity, it can be updated in future.
 
-**2. Ternary operators**  
+**2. Ternary operators**
 The following code from `SDF_example_001.c` is not supported:
 ```
 count_a = fifo->head + count <= fifo->size ? count : fifo->size - fifo->head;
 ```
-
 
 ## Note: things need to take care of in C codegen
 
 - Printing function pointer parameters may introduce ambiguity and differs from printing other types. It is not simply a matter of printing the type followed by the variable name, as the variable name is embedded within the type syntax. For example:
     - `void *f(token*, token*)` represents a function returning a pointer.
     - `void (*f)(token*, token*)` represents a function pointer variable.
-    
+
     Since our mainly usage of function pointer as function parameters and it is rare to use it in other places, this can also be addressed in later stage by defining an explicit template of printing parameters with type `TFunctionPointer`.
-
-

--- a/src/CoreIRToProceduralIR.hs
+++ b/src/CoreIRToProceduralIR.hs
@@ -232,7 +232,7 @@ translateFunctionContent context contentList =
             Nothing -> error "translateFunctionContent - empty expression stack when popping"
             Just (elist, stack1) -> (elist, stack1)
           (expr1, expr2, exprTail) = case exprList of
-            (e1 : e2 : eTail) -> (EParen e1, EParen e2, eTail)
+            (e1 : e2 : eTail) -> (e1, e2, eTail)
             _ -> error ("translateFunctionContent - insufficient operands for " ++ show binOp)
           newExpr = EBinOp binOp expr1 expr2
           newExprList = newExpr : exprTail

--- a/src/ProceduralIR.hs
+++ b/src/ProceduralIR.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE LambdaCase #-}
+
 module ProceduralIR
   ( UnaryOperator (..),
     BinaryOperator (..),
@@ -8,6 +10,7 @@ module ProceduralIR
     Program (..),
     StorageClass (..),
     TypeQualifier (..),
+    Associativity (..),
     prettyStorageClass,
     prettyTypeQualifier,
     prettyBinaryOperator,
@@ -17,6 +20,8 @@ module ProceduralIR
     prettyStatement,
     prettyGlobal,
     prettyProgram,
+    associativity,
+    precedence,
   )
 where
 
@@ -61,6 +66,76 @@ data BinaryOperator
   | Greater -- lhs > rhs
   | GreaterEqual -- lhs >= rhs
   deriving (Show)
+
+data Associativity
+  = ALeft
+  | ARight
+
+class Operator e where
+  precedence :: e -> Int
+  associativity :: e -> Associativity
+
+instance Operator UnaryOperator where
+  precedence = \case
+    Increment -> 15
+    Decrement -> 15
+    -- prefix inc/dec 14
+    Negate -> 14
+    LogicalNot -> 14
+    -- type-cast 13
+
+  associativity = \case
+    Increment -> ALeft
+    Decrement -> ALeft
+    Negate -> ARight
+    LogicalNot -> ARight
+
+instance Operator BinaryOperator where
+  precedence = \case
+    Multiply -> 12
+    Divide -> 12
+    Modulo -> 12
+    Plus -> 11
+    Minus -> 11
+    -- shift 10
+    Less -> 9
+    Greater -> 9
+    LessEqual -> 9
+    GreaterEqual -> 9
+    Equal -> 8
+    NotEqual -> 8
+    -- and 7
+    -- xor 6
+    -- or 5
+    LogicalAnd -> 4
+    LogicalOr -> 3
+    -- ternary 2
+    PlusAssign -> 1
+    MinusAssign -> 1
+    MultiplyAssign -> 1
+    DivideAssign -> 1
+    ModuloAssign -> 1
+    -- comma 0
+
+  associativity = \case
+    Plus -> ALeft
+    Minus -> ALeft
+    Multiply -> ALeft
+    Divide -> ALeft
+    Modulo -> ALeft
+    PlusAssign -> ARight
+    MinusAssign -> ARight
+    MultiplyAssign -> ARight
+    DivideAssign -> ARight
+    ModuloAssign -> ARight
+    Equal -> ARight
+    NotEqual -> ALeft
+    LogicalAnd -> ALeft
+    LogicalOr -> ALeft
+    Less -> ALeft
+    LessEqual -> ALeft
+    Greater -> ALeft
+    GreaterEqual -> ALeft
 
 -- Types
 data Type

--- a/src/ProceduralIRToC.hs
+++ b/src/ProceduralIRToC.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE LambdaCase #-}
+
 module ProceduralIRToC where
 
 import ArgumentsMain (InputType (Predefined, StdIn), Target (PC, PICO2))
@@ -7,6 +9,63 @@ import Text.Printf (printf)
 
 indent :: String -> String
 indent = unlines . map ("    " ++) . lines
+
+-- Helper function to place parentheses around operators depending on their
+-- precedence and associativity
+wrapExpression :: Expression -> Expression
+wrapExpression = \case
+  EUnOp op e ->
+    case e of
+      EBinOp op1 _ _ ->
+        if precedence op > precedence op1
+          then EUnOp op (EParen e)
+          else EUnOp op e
+      EUnOp op1 _ ->
+        if precedence op > precedence op1
+          then EUnOp op (EParen e)
+          else EUnOp op e
+      _ -> EUnOp op e
+  EBinOp op e1 e2 ->
+    case associativity op of
+      ALeft ->
+        case (e1, e2) of
+          (EBinOp op1 _ _, EBinOp _ _ _) ->
+            if precedence op > precedence op1
+              then EBinOp op (EParen e1) (EParen e2)
+              else EBinOp op e1 (EParen e2)
+          (EUnOp op1 _, EBinOp _ _ _) ->
+            if precedence op > precedence op1
+              then EBinOp op (EParen e1) (EParen e2)
+              else EBinOp op e1 (EParen e2)
+          (EBinOp op1 _ _, _) ->
+            if precedence op > precedence op1
+              then EBinOp op (EParen e1) e2
+              else EBinOp op e1 e2
+          (EUnOp op1 _, _) ->
+            if precedence op > precedence op1
+              then EBinOp op (EParen e1) e2
+              else EBinOp op e1 e2
+          _ -> EBinOp op e1 e2
+      ARight ->
+        case (e1, e2) of
+          (EBinOp _ _ _, EBinOp op2 _ _) ->
+            if precedence op > precedence op2
+              then EBinOp op (EParen e1) (EParen e2)
+              else EBinOp op (EParen e1) e2
+          (EBinOp _ _ _, EUnOp op2 _) ->
+            if precedence op > precedence op2
+              then EBinOp op (EParen e1) (EParen e2)
+              else EBinOp op (EParen e1) e2
+          (_, EBinOp op2 _ _) ->
+            if precedence op > precedence op2
+              then EBinOp op e1 (EParen e2)
+              else EBinOp op e1 e2
+          (_, EUnOp op2 _) ->
+            if precedence op > precedence op2
+              then EBinOp op e1 (EParen e2)
+              else EBinOp op e1 e2
+          _ -> EBinOp op e1 e2
+  e -> e
 
 stripSemicolon :: String -> String
 stripSemicolon str =
@@ -60,34 +119,35 @@ translateType currentType = case currentType of
       ++ ")"
 
 translateExpression :: Expression -> String
-translateExpression (EVar x) = x
-translateExpression (EInt i) = show i
-translateExpression (EChar c) = show c
-translateExpression (EString s) = show s
-translateExpression (EBinOp bop exprA exprB) =
-  translateExpression exprA ++ " " ++ translateBinaryOperator bop ++ " " ++ translateExpression exprB
-translateExpression (EUnOp unop@Increment expr) =
-  translateExpression expr ++ translateUnaryOperator unop
-translateExpression (EUnOp unop@Decrement expr) =
-  translateExpression expr ++ translateUnaryOperator unop
-translateExpression (EUnOp unop expr) =
-  translateUnaryOperator unop ++ translateExpression expr
-translateExpression (ECall name arguments) =
-  name ++ "(" ++ intercalate ", " (map translateExpression arguments) ++ ")"
-translateExpression (ECallExpr calleeExpr arguments) =
-  translateExpression calleeExpr ++ "(" ++ intercalate ", " (map translateExpression arguments) ++ ")"
-translateExpression (EArrayAccess arrayExpr indexExpr) =
-  translateExpression arrayExpr ++ "[" ++ translateExpression indexExpr ++ "]"
-translateExpression (EReference expr) =
-  "&" ++ translateExpression expr
-translateExpression (EDereference expr) =
-  "*" ++ translateExpression expr
-translateExpression (EMemberAccess expr field) =
-  translateExpression expr ++ "." ++ field
-translateExpression (EPointerAccess expr field) =
-  translateExpression expr ++ "->" ++ field
-translateExpression (EParen expr) =
-  "(" ++ translateExpression expr ++ ")"
+translateExpression expr' =
+  case wrapExpression expr' of
+    EVar x -> x
+    EInt i -> show i
+    EChar c -> show c
+    EString s -> show s
+    EBinOp bop exprA exprB ->
+      translateExpression exprA ++ " " ++ translateBinaryOperator bop ++ " " ++ translateExpression exprB
+    EUnOp op expr ->
+      case op of
+        Increment -> translateExpression expr ++ translateUnaryOperator op
+        Decrement -> translateExpression expr ++ translateUnaryOperator op
+        _ -> translateUnaryOperator op ++ translateExpression expr
+    ECall name arguments ->
+      name ++ "(" ++ intercalate ", " (map translateExpression arguments) ++ ")"
+    ECallExpr calleeExpr arguments ->
+      translateExpression calleeExpr ++ "(" ++ intercalate ", " (map translateExpression arguments) ++ ")"
+    EArrayAccess arrayExpr indexExpr ->
+      translateExpression arrayExpr ++ "[" ++ translateExpression indexExpr ++ "]"
+    EReference expr ->
+      "&" ++ translateExpression expr
+    EDereference expr ->
+      "*" ++ translateExpression expr
+    EMemberAccess expr field ->
+      translateExpression expr ++ "." ++ field
+    EPointerAccess expr field ->
+      translateExpression expr ++ "->" ++ field
+    EParen expr ->
+      "(" ++ translateExpression expr ++ ")"
 
 translateStatement :: Statement -> String
 translateStatement (SExpr expression) =


### PR DESCRIPTION
Attempt to place parentheses according to precedence and associativity for C according to `man 7 operator`.

This is now done in `ProceduralIRToC` so we won't have to care about placement of parentheses in other places in the future (since `ProceduralIR` is more akin to an AST and thus does not need parentheses really).