### PR TITLE
Match more possible patterns for process constructors

### DIFF
--- a/examples/model/SDF_example_027.hs
+++ b/examples/model/SDF_example_027.hs
@@ -10,9 +10,11 @@ system s_in = s_out
     s_6 = p_3 s_3 s_5
     (s_out, s_4) = p_4 s_2
     s_5 = p_5 s_4
-    s_6_delayed = delaySDF [0, 0] s_6
+    s_6_delayed = d_1 s_6
 
 -- Process Specification
+d_1 = delaySDF [0, 0]
+
 p_1 = actor21SDF (2, 1) 1 f_1
   where
     f_1 [x1, x2] [y] = [x1 + x2 + y]

--- a/examples/model/SDF_example_028.hs
+++ b/examples/model/SDF_example_028.hs
@@ -1,0 +1,23 @@
+module SDF_example_028 where
+
+import ForSyDe.Shallow
+
+-- Netlist
+system :: Signal Int -> Signal Int -> Signal Int
+system s_in_x s_in_y = s_out
+  where
+    s_1 = a_a s_in_x s_in_y
+    (s_out, s_2) = a_b s_1 s_2_delayed
+    s_2_delayed = d_1 s_2
+
+-- Process specifications
+a_a s_1 s_2 = actor21SDF (1, 1) 1 add s_1 s_2
+
+a_b s_1 s_2 = actor22SDF (1, 1) (1, 1) accumulate s_1 s_2
+
+d_1 s = delaySDF [0] s
+
+-- Function definitions
+add [x] [y] = [x + y]
+
+accumulate [x] [y] = ([x + y], [x + y])

--- a/examples/model/SDF_example_029.hs
+++ b/examples/model/SDF_example_029.hs
@@ -1,0 +1,23 @@
+module SDF_example_029 where
+
+import ForSyDe.Shallow
+
+-- Netlist
+system :: Signal Int -> Signal Int -> Signal Int
+system s_in_x s_in_y = s_out
+  where
+    s_1 = a_a s_in_x s_in_y
+    (s_out, s_2) = a_b s_1 s_2_delayed
+    s_2_delayed = d_1 s_2
+
+-- Process specifications
+a_a = actor21SDF (1, 1) 1 add
+
+a_b = actor22SDF (1, 1) (1, 1) accumulate
+
+d_1 = delaySDF [0]
+
+-- Function definitions
+add [x] [y] = [x + y]
+
+accumulate [x] [y] = ([x + y], [x + y])

--- a/examples/model/SDF_example_030.hs
+++ b/examples/model/SDF_example_030.hs
@@ -1,0 +1,22 @@
+module SDF_example_030 where
+
+import ForSyDe.Shallow
+
+-- Netlist
+system s_in_x s_in_y = s_out
+  where
+    s_1 = a_a s_in_x s_in_y
+    (s_out, s_2) = a_b s_1 s_2_delayed
+    s_2_delayed = d_1 s_2
+
+-- Process specifications
+a_a = actor21SDF (1, 1) 1 add
+  where
+    add [x] [y] = [x + y]
+
+a_b :: Signal Int -> Signal Int -> (Signal Int, Signal Int)
+a_b s_1 s_2 = actor22SDF (1, 1) (1, 1) accumulate s_1 s_2
+  where
+    accumulate [x] [y] = ([x + y], [x + y])
+
+d_1 s = delaySDF [0] s

--- a/src/CoreIRToForSyDeIR.hs
+++ b/src/CoreIRToForSyDeIR.hs
@@ -231,8 +231,23 @@ translateSystemExpr initialContext expr = case expr of
         context1 = createSignalsFromArguments initialContext pcId arguments
         binder = PcId pcId
      in (binder, context1)
+  App (App (App (Var i) (Type _)) (Var _)) (Var a) ->
+    let pcId = IRVar i
+        aId = IRVar a
+        arguments = [aId]
+        context1 = createSignalsFromArguments initialContext pcId arguments
+        binder = PcId pcId
+     in (binder, context1)
   -- Application of process constructors with 2 input
   App (App (Var i) (Var a1)) (Var a2) ->
+    let pcId = IRVar i
+        a1Id = IRVar a1
+        a2Id = IRVar a2
+        arguments = [a1Id, a2Id]
+        context1 = createSignalsFromArguments initialContext pcId arguments
+        binder = PcId pcId
+     in (binder, context1)
+  App (App (App (App (Var i) (Type _)) (Var _)) (Var a1)) (Var a2) ->
     let pcId = IRVar i
         a1Id = IRVar a1
         a2Id = IRVar a2
@@ -250,8 +265,27 @@ translateSystemExpr initialContext expr = case expr of
         context1 = createSignalsFromArguments initialContext pcId arguments
         binder = PcId pcId
      in (binder, context1)
+  App (App (App (App (App (Var i) (Type _)) (Var _)) (Var a1)) (Var a2)) (Var a3) ->
+    let pcId = IRVar i
+        a1Id = IRVar a1
+        a2Id = IRVar a2
+        a3Id = IRVar a3
+        arguments = [a1Id, a2Id, a3Id]
+        context1 = createSignalsFromArguments initialContext pcId arguments
+        binder = PcId pcId
+     in (binder, context1)
   -- Application of process constructors with 4 input
   App (App (App (App (Var i) (Var a1)) (Var a2)) (Var a3)) (Var a4) ->
+    let pcId = IRVar i
+        a1Id = IRVar a1
+        a2Id = IRVar a2
+        a3Id = IRVar a3
+        a4Id = IRVar a4
+        arguments = [a1Id, a2Id, a3Id, a4Id]
+        context1 = createSignalsFromArguments initialContext pcId arguments
+        binder = PcId pcId
+     in (binder, context1)
+  App (App (App (App (App (App (Var i) (Type _)) (Var _)) (Var a1)) (Var a2)) (Var a3)) (Var a4) ->
     let pcId = IRVar i
         a1Id = IRVar a1
         a2Id = IRVar a2

--- a/src/CoreIRToForSyDeIR.hs
+++ b/src/CoreIRToForSyDeIR.hs
@@ -5,6 +5,7 @@ import Data.List (elemIndex)
 import ForSyDeIR
 import GHC hiding (targetId)
 import GHC.Core
+import GHC.Types.Var (isTyVar)
 
 -- | The `TranslationContext` is a data type which is used to pass around
 -- context required to complete the translation of Core IR to ForSyDe IR.
@@ -349,6 +350,22 @@ getSourceFromArgument context argument =
             Just (Binding bindingId index) -> (bindingId, index)
             Nothing -> error ("getSourceFromArgument - Unable to identify argument as a system input or binder: " ++ show argument)
 
+-- Strip all Lams so we don't need to bother with non-eta-reduced processes.
+-- We con't count the type variables as those won't produce an App in the top
+-- level definition.
+stripLams :: Integer -> CoreExpr -> (Integer, CoreExpr)
+stripLams n expr = case expr of
+  Lam b (Lam _ e) | isTyVar b -> stripLams n e
+  Lam _ e | otherwise -> stripLams (n + 1) e
+  _ -> (n, expr)
+
+-- Strip n Apps if possible, otherwise Nothing
+stripApps :: Integer -> CoreExpr -> Maybe CoreExpr
+stripApps n expr = case expr of
+  App e _ | n > 0 -> stripApps (n - 1) e
+  _ | n > 0 -> Nothing
+  _ | otherwise -> Just expr
+
 -- | Creates actors and delays by pattern matching based on the number of
 -- inputs to the top level function, represented by `Lam`, and inputs to the
 -- process constructor, represented by `App`. If it cannot match an actor or
@@ -357,42 +374,49 @@ getSourceFromArgument context argument =
 -- NOTE: This function needs to be updated with new pattern matches for
 -- translation to support additional process constructors.
 translateCoreExpr :: TranslationContext -> CoreBndr -> CoreExpr -> TranslationContext
-translateCoreExpr context binder expr = case expr of
-  Lam _ (App (App (App (Var i) _) _) _)
-    | IRVar i == IRString "delaySDF" -> createDelaySDF context binder expr
-  Lam _ (App (App (App (App (App (App (Var i) _) _) _) _) _) _)
-    | IRVar i == IRString "actor11SDF" -> createActorSDF context Actor11 binder expr
-  Lam _ (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _)
-    | IRVar i == IRString "actor12SDF" -> createActorSDF context Actor12 binder expr
-  Lam _ (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _)
-    | IRVar i == IRString "actor13SDF" -> createActorSDF context Actor13 binder expr
-  Lam _ (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _)
-    | IRVar i == IRString "actor14SDF" -> createActorSDF context Actor14 binder expr
-  Lam _ (Lam _ (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _))
-    | IRVar i == IRString "actor21SDF" -> createActorSDF context Actor21 binder expr
-  Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _))
-    | IRVar i == IRString "actor22SDF" -> createActorSDF context Actor22 binder expr
-  Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _))
-    | IRVar i == IRString "actor23SDF" -> createActorSDF context Actor23 binder expr
-  Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _))
-    | IRVar i == IRString "actor24SDF" -> createActorSDF context Actor24 binder expr
-  Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _)))
-    | IRVar i == IRString "actor31SDF" -> createActorSDF context Actor31 binder expr
-  Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _)))
-    | IRVar i == IRString "actor32SDF" -> createActorSDF context Actor32 binder expr
-  Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _) _)))
-    | IRVar i == IRString "actor33SDF" -> createActorSDF context Actor33 binder expr
-  Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _) _) _)))
-    | IRVar i == IRString "actor34SDF" -> createActorSDF context Actor34 binder expr
-  Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _) _))))
-    | IRVar i == IRString "actor41SDF" -> createActorSDF context Actor41 binder expr
-  Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _) _) _))))
-    | IRVar i == IRString "actor42SDF" -> createActorSDF context Actor42 binder expr
-  Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _) _) _) _))))
-    | IRVar i == IRString "actor43SDF" -> createActorSDF context Actor43 binder expr
-  Lam _ (Lam _ (Lam _ (Lam _ (App (App (App (App (App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _) _) _) _) _))))
-    | IRVar i == IRString "actor44SDF" -> createActorSDF context Actor44 binder expr
-  _ -> createFunction context binder expr
+translateCoreExpr context' binder expr' =
+  let (n, expr1) = stripLams 0 expr'
+      (context, expr2) = case expr1 of
+        Let (NonRec bn be) e -> (createFunction context' bn be, e)
+        Let _ e -> (context', e)
+        _ -> (context', expr1)
+      expr = maybe expr' id (stripApps n expr2)
+   in case expr of
+        App (App (Var i) _) _
+          | IRVar i == IRString "delaySDF" -> createDelaySDF context binder expr
+        App (App (App (App (App (Var i) _) _) _) _) _
+          | IRVar i == IRString "actor11SDF" -> createActorSDF context Actor11 binder expr
+        App (App (App (App (App (App (Var i) _) _) _) _) _) _
+          | IRVar i == IRString "actor12SDF" -> createActorSDF context Actor12 binder expr
+        App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _
+          | IRVar i == IRString "actor13SDF" -> createActorSDF context Actor13 binder expr
+        App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _
+          | IRVar i == IRString "actor14SDF" -> createActorSDF context Actor14 binder expr
+        App (App (App (App (App (App (Var i) _) _) _) _) _) _
+          | IRVar i == IRString "actor21SDF" -> createActorSDF context Actor21 binder expr
+        App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _
+          | IRVar i == IRString "actor22SDF" -> createActorSDF context Actor22 binder expr
+        App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _
+          | IRVar i == IRString "actor23SDF" -> createActorSDF context Actor23 binder expr
+        App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _
+          | IRVar i == IRString "actor24SDF" -> createActorSDF context Actor24 binder expr
+        App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _
+          | IRVar i == IRString "actor31SDF" -> createActorSDF context Actor31 binder expr
+        App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _
+          | IRVar i == IRString "actor32SDF" -> createActorSDF context Actor32 binder expr
+        App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _
+          | IRVar i == IRString "actor33SDF" -> createActorSDF context Actor33 binder expr
+        App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _
+          | IRVar i == IRString "actor34SDF" -> createActorSDF context Actor34 binder expr
+        App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _
+          | IRVar i == IRString "actor41SDF" -> createActorSDF context Actor41 binder expr
+        App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _
+          | IRVar i == IRString "actor42SDF" -> createActorSDF context Actor42 binder expr
+        App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _
+          | IRVar i == IRString "actor43SDF" -> createActorSDF context Actor43 binder expr
+        App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _
+          | IRVar i == IRString "actor44SDF" -> createActorSDF context Actor44 binder expr
+        _ -> createFunction context binder expr
 
 createDelaySDF :: TranslationContext -> CoreBndr -> CoreExpr -> TranslationContext
 createDelaySDF context binder expr =

--- a/src/CoreIRToForSyDeIR.hs
+++ b/src/CoreIRToForSyDeIR.hs
@@ -76,6 +76,9 @@ translateCoreBind _ (Rec _) = error "translateCoreBind - `Rec` used in top level
 -- and identifies system outputs.
 translateSystem :: TranslationContext -> CoreExpr -> TranslationContext
 translateSystem initialContext expr = case expr of
+  -- Ignores Lambdas that refer to binders which are typed, always comes in
+  -- pairs. These Lambdas are resent when no explicit type is declared.
+  Lam b (Lam _ e) | isTyVar b -> translateSystem initialContext e
   Lam b e ->
     let newInput = IRVar b
         context1 = initialContext {systemInputs = newInput : (systemInputs initialContext)}

--- a/src/CoreIRToProceduralIR.hs
+++ b/src/CoreIRToProceduralIR.hs
@@ -5,14 +5,13 @@
 
 module CoreIRToProceduralIR where
 
-import CoreIR (literalToInt, prettyCoreAlt, varToString)
+import CoreIR (literalToInt, prettyCoreAlt)
 import Data.List (elemIndex)
 import Data.Maybe (mapMaybe)
 import ForSyDeIR
 import GHC hiding (Type, targetId)
 import GHC.Core
-import GHC.Driver.Ppr (showPpr)
-import GHC.Plugins (Var)
+import GHC.Plugins hiding (Type)
 import ProceduralIR
 import Utilities (Stack, emptyStack, pop, push, stackToList)
 
@@ -117,6 +116,9 @@ getFunctionDefinition context parametersList functionId =
 -- matched binder represents.
 translateFunctionExpr :: TranslationContext -> Int -> Int -> CoreExpr -> TranslationContext
 translateFunctionExpr context inputId inputIndex expr = case expr of
+  -- Ignores Lambdas that refer to binders which are typed, always comes in
+  -- pairs. These Lambdas are resent when no explicit type is declared.
+  Lam b (Lam _ e) | isTyVar b -> translateFunctionExpr context inputId inputIndex e
   -- Function with 4 inputs
   Lam b1 (Lam b2 (Lam b3 (Lam b4 e))) ->
     let context1 = context {functionInputs = [(IRVar b1), (IRVar b2), (IRVar b3), (IRVar b4)]}
@@ -195,15 +197,15 @@ translateOutputExprToFunctionContentList context expr acc = case expr of
     "(,,)" -> FTuple : acc
     "(,,,)" -> FTuple : acc
     "[]" -> FEmptyList : acc
-    "I#" -> acc
-    "$fNumInt" -> acc
-    "$fIntegralInt" -> acc
     "+" -> FPlus : acc
     "-" -> FMinus : acc
     "*" -> FMultiply : acc
     "div" -> FDiv : acc
     "negate" -> FNegate : acc
-    _ -> FVar varId : acc
+    -- Only adds current variable id if its associated to a current variable expression
+    _ -> case lookup (IRVar varId) (functionVariables context) of
+      Just _ -> FVar varId : acc
+      Nothing -> acc
   Lit i -> FInt (literalToInt i) : acc
   _ -> acc
 
@@ -258,7 +260,7 @@ translateFunctionContent context contentList =
               Just (elist, stack1) -> (elist, stack1)
             variableExpr = case lookup (IRVar varId) (functionVariables context) of
               Just expr -> expr
-              Nothing -> error ("translateFunctionContent - variable not found: " ++ varToString varId)
+              Nothing -> error ("translateFunctionContent - variable not found: " ++ showPpr (flags context) varId)
             newExprList = variableExpr : exprList
             exprsStack2 = push newExprList exprsStack1
          in exprsStack2

--- a/src/CoreIRToProceduralIR.hs
+++ b/src/CoreIRToProceduralIR.hs
@@ -7,7 +7,7 @@ module CoreIRToProceduralIR where
 
 import CoreIR (literalToInt, prettyCoreAlt, varToString)
 import Data.List (elemIndex)
-import Data.Maybe (listToMaybe, mapMaybe)
+import Data.Maybe (mapMaybe)
 import ForSyDeIR
 import GHC hiding (Type, targetId)
 import GHC.Core
@@ -54,38 +54,37 @@ initialTranslationContext dflags =
 
 -- | Translates an `IRFunction` into a Procedural IR function declaration and
 -- optional definition.
-translateIRFunction :: IRFunction -> DynFlags -> [IRConstructor] -> (Global, Maybe Global)
+translateIRFunction :: IRFunction -> DynFlags -> [IRConstructor] -> Maybe (Global, Maybe Global)
 translateIRFunction function dflags constructors =
   let context = initialTranslationContext dflags
    in case function of
         IRFunction functionId Nothing ->
-          let actor = case (findActorFromFunctionId functionId constructors) of
-                Nothing -> error ("translateIRFunction - no actor associated to " ++ show functionId)
-                Just a -> a
-              (parameterList, _context1) = getParameterList context actor
-              (functionDeclarationGlobal) = getFunctionDeclaration parameterList functionId
-           in (functionDeclarationGlobal, Nothing)
+          case (findActorFromFunctionId functionId constructors) of
+            [] -> Nothing
+            actor : _ ->
+              let (parameterList, _context1) = getParameterList context actor
+                  (functionDeclarationGlobal) = getFunctionDeclaration parameterList functionId
+               in Just (functionDeclarationGlobal, Nothing)
         IRFunction functionId (Just functionExpr) ->
-          let actor = case (findActorFromFunctionId functionId constructors) of
-                Nothing -> error ("translateIRFunction - no actor associated to " ++ show functionId)
-                Just a -> a
-              (parameterList, context1) = getParameterList context actor
-              functionDeclarationGlobal = getFunctionDeclaration parameterList functionId
-              context2 = translateFunctionExpr context1 0 0 functionExpr
-              functionDefinitionGlobal = getFunctionDefinition context2 parameterList functionId
-           in (functionDeclarationGlobal, Just functionDefinitionGlobal)
+          case (findActorFromFunctionId functionId constructors) of
+            [] -> Nothing
+            actor : _ ->
+              let (parameterList, context1) = getParameterList context actor
+                  functionDeclarationGlobal = getFunctionDeclaration parameterList functionId
+                  context2 = translateFunctionExpr context1 0 0 functionExpr
+                  functionDefinitionGlobal = getFunctionDefinition context2 parameterList functionId
+               in Just (functionDeclarationGlobal, Just functionDefinitionGlobal)
 
--- Helper function which identifies which `IRActor` is associated with a
--- provided function id. If successful returns the actor as an optional
--- `IRConstructor` otherwise returns `Nothing`.
-findActorFromFunctionId :: IRId -> [IRConstructor] -> Maybe IRConstructor
+-- Helper function which returns the `IRActor`s associated with a provided
+-- function id
+findActorFromFunctionId :: IRId -> [IRConstructor] -> [IRConstructor]
 findActorFromFunctionId targetFunctionId constructors =
   let checkIRConstructor :: IRConstructor -> Maybe IRConstructor
       checkIRConstructor actor@(IRActor _ _ functionId _)
         | functionId == targetFunctionId = Just actor
         | otherwise = Nothing
       checkIRConstructor _ = Nothing
-   in listToMaybe (mapMaybe checkIRConstructor constructors)
+   in mapMaybe checkIRConstructor constructors
 
 -- Helper function which builds the parameter list for a `ProceduralIR` function
 -- based on the input and output signals of provided actor. Updates the

--- a/src/ForSyDeIRToProceduralIR.hs
+++ b/src/ForSyDeIRToProceduralIR.hs
@@ -337,6 +337,7 @@ getScheduleBufferRate actorId bufferList =
 translateIRFunctionToGlobals :: [IRConstructor] -> TranslationContext -> IRFunction -> TranslationContext
 translateIRFunctionToGlobals constructors currentContext function =
   let context1 = case (translateIRFunction function (flags currentContext) constructors) of
-        (functionDeclaration, Just functionDefinition) -> currentContext {initFunctions = functionDeclaration : (initFunctions currentContext), functions = functionDefinition : (functions currentContext)}
-        (functionDeclaration, Nothing) -> currentContext {initFunctions = functionDeclaration : (initFunctions currentContext)}
+        Just (functionDeclaration, Just functionDefinition) -> currentContext {initFunctions = functionDeclaration : (initFunctions currentContext), functions = functionDefinition : (functions currentContext)}
+        Just (functionDeclaration, Nothing) -> currentContext {initFunctions = functionDeclaration : (initFunctions currentContext)}
+        Nothing -> currentContext
    in context1

--- a/src/Utilities.hs
+++ b/src/Utilities.hs
@@ -103,10 +103,7 @@ noInlineTypecheck tcg = tcg {tcg_binds = applySystemBinds (tcg_binds tcg)}
     checkFunBind bind =
       case bind of
         FunBind {fun_id = var, fun_matches = matches} ->
-          let funName = occNameString (occName (unLoc var))
-           in case funName of
-                "system" -> bind {fun_id = var, fun_matches = applyLocalBinds matches}
-                _ -> bind
+          bind {fun_id = var, fun_matches = applyLocalBinds matches}
         _ -> applySystemBinds bind
 
     applyLocalBinds :: (Data a) => a -> a


### PR DESCRIPTION
While looking at handling exceptions in the LSP, I figured that it might be good to just have the compiler crash less. I started looking at the eta-reduced cases which turned out to not be too hard to fix. Basically, the eta-reduced applications have no Lams in the beginning and then an equal number of Apps removed. Just strip preceeding Lams and an equal number of Apps before matching with the eta-reduced cases instead.

This also attempts to lift local functions in where-scopes to global functions. This might not be the best approach, but seemed to be the least amount of work. Ideally, we should maybe instead change ForSyDeIR to have the functions embedded directly. This would also make it easier when functions are defined globally since we don't need to link them together in CoreIRToProceduralIR. We could then also just ignore any unused global functions.

This also changes the noInlineTypecheck to put NOINLINE on all functions definitions, not just the ones in system.

With a few other changes, this PR also now supports inferred types (but this probably needs more testing). The major remaining restriction after this is that actor definitions still cannot be inlined in the system net list.