### PR TITLE
Change help text so it says C output is default

### DIFF
--- a/src/ArgumentsMain.hs
+++ b/src/ArgumentsMain.hs
@@ -150,7 +150,7 @@ outputFormatC =
     OutputC
     OutputC
     ( long "output-c"
-        <> help "Output file in C"
+        <> help "Output file in C (default)"
     )
 
 outputFormatCore :: Parser OutputFormat
@@ -158,7 +158,7 @@ outputFormatCore =
   flag'
     OutputCore
     ( long "output-core"
-        <> help "Output file in Core (default)"
+        <> help "Output file in Core"
     )
 
 outputFormatForSyDeIR :: Parser OutputFormat


### PR DESCRIPTION
As Ingo mentioned, the help screen writes the following:

```
sam@fedora:~/Documents/IL2232/forsyde-devtools$ stack run forsyde-compiler-exe -- --help
ForSyDe DevTools

Usage: forsyde-compiler-exe INPUT [(-o|--output OUTPUT) | --stdout] 
                            [--output-c | --output-core | --output-forsyde-ir | 
                              --output-forsyde-ir-json | 
                              --output-procedural-ir | --output-schedule] 
                            [-t|--target TARGET] [--input-type INPUTTYPE] 
                            [--runs RUNS] [--forsyde-pkgpath ARG]

  Compile a ForSyDe model

Available options:
  INPUT                    Input filename
  -o,--output OUTPUT       Output filename
  --stdout                 Print output to stdout
  --output-c               Output file in C
  --output-core            Output file in Core (default)
  --output-forsyde-ir      Output file in ForSyDe-IR
  --output-forsyde-ir-json Output file in ForSyDe-IR-JSON
  --output-procedural-ir   Output file in Procedural-IR
  --output-schedule        Output the SDF schedule to file instead of code
  -t,--target TARGET       Target platform for C code. (PC default, PC and PICO2
                           supported)
  --input-type INPUTTYPE   Source of input tokens for the SDF models in the C
                           code. (stdin default, stdin and predefined supported)
  --runs RUNS              How many times to loop input data, when input mode is
                           set to 'predefined'. 1 By default, pass an integer
                           for a limited number or 'inf' to run the program
                           perpetually
  --forsyde-pkgpath ARG    The path to the ForSyDe Shallow package (unspecified
                           by default)
  -h,--help                Show this help text
```

which states that `--output-core` is default which is wrong now. Change so that the help screen instead writes

```
sam@fedora:~/Documents/IL2232/forsyde-devtools$ stack run forsyde-compiler-exe -- --help
ForSyDe DevTools

Usage: forsyde-compiler-exe INPUT [(-o|--output OUTPUT) | --stdout] 
                            [--output-c | --output-core | --output-forsyde-ir | 
                              --output-forsyde-ir-json | 
                              --output-procedural-ir | --output-schedule] 
                            [-t|--target TARGET] [--input-type INPUTTYPE] 
                            [--runs RUNS] [--forsyde-pkgpath ARG]

  Compile a ForSyDe model

Available options:
  INPUT                    Input filename
  -o,--output OUTPUT       Output filename
  --stdout                 Print output to stdout
  --output-c               Output file in C (default)
  --output-core            Output file in Core
  --output-forsyde-ir      Output file in ForSyDe-IR
  --output-forsyde-ir-json Output file in ForSyDe-IR-JSON
  --output-procedural-ir   Output file in Procedural-IR
  --output-schedule        Output the SDF schedule to file instead of code
  -t,--target TARGET       Target platform for C code. (PC default, PC and PICO2
                           supported)
  --input-type INPUTTYPE   Source of input tokens for the SDF models in the C
                           code. (stdin default, stdin and predefined supported)
  --runs RUNS              How many times to loop input data, when input mode is
                           set to 'predefined'. 1 By default, pass an integer
                           for a limited number or 'inf' to run the program
                           perpetually
  --forsyde-pkgpath ARG    The path to the ForSyDe Shallow package (unspecified
                           by default)
  -h,--help                Show this help text
```
so that it says that `output-c` is default