### PR TITLE
Undefined functions

### DIFF
--- a/examples/model/SDF_example_031.hs
+++ b/examples/model/SDF_example_031.hs
@@ -1,0 +1,28 @@
+module SDF_example_031 where
+
+import ForSyDe.Shallow
+
+-- Netlist
+system :: Signal Int -> Signal Int -> Signal Int
+system s_in_x s_in_y = s_out
+  where
+    s_1 = a_a s_in_x s_in_y
+    (s_out, s_2) = a_b s_1 s_2_delayed
+    s_2_delayed = d_1 s_2
+
+-- Process specifications
+a_a :: Signal Int -> Signal Int -> Signal Int
+a_a s_1 s_2 = actor21SDF (1, 1) 1 add s_1 s_2
+
+a_b :: Signal Int -> Signal Int -> (Signal Int, Signal Int)
+a_b s_1 s_2 = actor22SDF (1, 1) (1, 1) accumulate s_1 s_2
+
+d_1 :: Signal Int -> Signal Int
+d_1 s = delaySDF [0] s
+
+-- Function definitions
+add :: [Int] -> [Int] -> [Int]
+add x y = undefined
+
+accumulate :: [Int] -> [Int] -> ([Int], [Int])
+accumulate x y = undefined

--- a/examples/model/SDF_example_032.hs
+++ b/examples/model/SDF_example_032.hs
@@ -1,0 +1,21 @@
+module SDF_example_032 where
+
+import ForSyDe.Shallow
+
+-- Netlist
+system :: Signal Int -> Signal Int -> Signal Int
+system s_in_x s_in_y = s_out
+  where
+    s_1 = a_a s_in_x s_in_y
+    (s_out, s_2) = a_b s_1 s_2_delayed
+    s_2_delayed = d_1 s_2
+
+-- Process specifications
+a_a :: Signal Int -> Signal Int -> Signal Int
+a_a s_1 s_2 = actor21SDF (1, 1) 1 undefined s_1 s_2
+
+a_b :: Signal Int -> Signal Int -> (Signal Int, Signal Int)
+a_b s_1 s_2 = actor22SDF (1, 1) (1, 1) undefined s_1 s_2
+
+d_1 :: Signal Int -> Signal Int
+d_1 s = delaySDF [0] s

--- a/src/CoreIRToForSyDeIR.hs
+++ b/src/CoreIRToForSyDeIR.hs
@@ -5,6 +5,9 @@ import Data.List (elemIndex)
 import ForSyDeIR
 import GHC hiding (targetId)
 import GHC.Core
+import GHC.Driver.Ppr (showPprUnsafe)
+import GHC.Plugins
+import GHC.Plugins (IdDetails (CoVarId))
 import GHC.Types.Var (isTyVar)
 
 -- | The `TranslationContext` is a data type which is used to pass around
@@ -63,10 +66,11 @@ translateCoreProgram dflags program =
 
 -- | Translates a top level `CoreBind`. Module information is currently ignored.
 translateCoreBind :: TranslationContext -> CoreBind -> TranslationContext
-translateCoreBind context (NonRec b e) = case show (IRVar b) of
-  "$trModule" -> context
-  "system" -> translateSystem context e
-  _ -> translateCoreExpr context b e
+translateCoreBind context (NonRec b e)
+  | IRVar b == IRString "$trModule" = context
+  | isSystemName (varName b) = context
+  | IRVar b == IRString "system" = translateSystem context e
+  | otherwise = translateCoreExpr context b e
 -- NOTE: Currently no SDF examples have a `Rec` in the top level of their Core
 -- output, thus unsure what the expected outcome should be.
 translateCoreBind _ (Rec _) = error "translateCoreBind - `Rec` used in top level of Core output"
@@ -511,10 +515,16 @@ getActorSplit actorType = case actorType of
   Actor44 -> 4
 
 createFunction :: TranslationContext -> CoreBndr -> CoreExpr -> TranslationContext
-createFunction context binder expr =
-  let functionId = IRVar binder
-      newFunction = IRFunction functionId (Just expr)
-   in context {functions = (functionId, newFunction) : (functions context)}
+createFunction context binder expr = case expr of
+  App (Var i) (Type _)
+    | IRVar i == IRString "undefined" ->
+        let functionId = IRVar binder
+            newFunction = IRFunction functionId Nothing
+         in context {functions = (functionId, newFunction) : (functions context)}
+  _ ->
+    let functionId = IRVar binder
+        newFunction = IRFunction functionId (Just expr)
+     in context {functions = (functionId, newFunction) : (functions context)}
 
 -- | Helper function for `createActorSDF` which returns name of the function
 -- used by the process constructor.
@@ -527,8 +537,10 @@ getFunctionName context expr = case expr of
           Nothing -> getFunctionName context e
   Lam _ e -> getFunctionName context e
   Let _ e -> getFunctionName context e
-  Var v ->
-    let name = IRVar v
+  -- Not the following results in undefined behaviour in C
+  Var i | IRVar i == IRString "undefined" -> Just (IRString "NULL")
+  Var i ->
+    let name = IRVar i
      in if any (\x -> case x of IRFunction functionName _ -> functionName == name) (map snd (functions context))
           then
             Just name

--- a/src/ForSyDeIR.hs
+++ b/src/ForSyDeIR.hs
@@ -114,7 +114,7 @@ data ActorType
   deriving (Show)
 
 -- IRDelay(delayId, tokens, (inputSignal, outputSignal))
--- IRActor(actorId, actorType, (inputSignals, outputSignals))
+-- IRActor(actorId, actorType, functionId (inputSignals, outputSignals))
 data IRConstructor
   = IRDelay IRId [Int] (IRId, IRId)
   | IRActor IRId ActorType IRId ([IRId], [IRId])

--- a/src/ForSyDeIRToProceduralIR.hs
+++ b/src/ForSyDeIRToProceduralIR.hs
@@ -148,7 +148,7 @@ translateBuffer initialContext (bufferId, bufferSize) =
           -- If input is predefined, then do not create "input_" arrays.
           -- But you still need to create the "s_" buffers for those signals
           Predefined ->
-            initialContext {ioTokens = ioTokens initialContext, initBuffers = initStmt : initBuffers initialContext, freeBuffers = freeStmt : freeBuffers initialContext}
+            initialContext {initBuffers = initStmt : initBuffers initialContext, freeBuffers = freeStmt : freeBuffers initialContext}
         else
           if (elem bufferId (systemOutputs initialContext))
             then


### PR DESCRIPTION
Adds support for undefined functions. Includes two additional SDF examples. In SDF example 31, the functions themselves are undefined, while in SDF example 32, undefined is used by the actors in place of a function name. Currently, only SDF example 31 is compilable to C code, while 32 fails to compile to ForSyDe IR. This is due to not having optional function IDs as a part of an `IRActor`, which it currently fails to find.

Also refines the approach used to ignore top-level Core IR constructs which relate to GHC-generated binders.