### PR TITLE
lsp: use u+25b6 black right-pointing triangle as arrowhead

### DIFF
--- a/src/LSP.hs
+++ b/src/LSP.hs
@@ -113,7 +113,7 @@ forSyDeIRToGraph filename (IRSystem (inputs, outputs) actors signals _) = graph
         nid = "$root$N$" <> T.show name
         insignals = findInputSignals signals name
         outsignals = findOutputSignals signals name
-        inports = map (createPort nid (maybe [] (\_l -> [KText "◆" []]) l) [PortSide 4]) insignals
+        inports = map (createPort nid (maybe [] (\_l -> [KText "▶" []]) l) [PortSide 4]) insignals
         outports = map (createPort nid [] [PortSide 2]) outsignals
         nl = maybe [] (\lc -> [KLabel {gid = nid <> "$L$" <> T.show name, label = T.show lc}]) l
         c = inports ++ outports ++ nl


### PR DESCRIPTION
We force input ports on the west side of nodes and output ports on the east side of nodes since a while. This means we always know which direction the edge arrowhead should point in, meaning we can use a directed symbol. The black right-pointing triangle (u+25b6) looks to work fine, change to that one.