### PR TITLE
Fix undefined

### DIFF
--- a/examples/model/SDF_example_033.hs
+++ b/examples/model/SDF_example_033.hs
@@ -1,0 +1,19 @@
+module SDF_example_033 where
+
+import ForSyDe.Shallow
+
+system s_in_x s_in_y = s_out
+  where
+    s_1 = a_a s_in_x s_in_y
+    (s_out, s_2) = a_b s_1 s_2_delayed
+    s_2_delayed = d_1 s_2
+
+-- Process specifications
+-- a_a :: Signal Int -> Signal Int -> Signal Int
+a_a = actor21SDF (1, 1) 1 undefined
+
+-- a_b :: Signal Int -> Signal Int -> (Signal Int, Signal Int)
+a_b = actor22SDF (1, 1) (1, 1) undefined
+
+-- d_1 :: Signal Int -> Signal Int
+d_1 = delaySDF [0]

--- a/examples/model/SDF_example_034.hs
+++ b/examples/model/SDF_example_034.hs
@@ -1,0 +1,11 @@
+module SDF_example_034 where
+
+import ForSyDe.Shallow
+
+-- Netlist
+system s_in = s_out
+  where
+    s_out = a_a s_in
+
+-- Process Constructors
+a_a = actor11SDF 1 1 undefined

--- a/examples/model/SDF_example_035.hs
+++ b/examples/model/SDF_example_035.hs
@@ -1,0 +1,12 @@
+module SDF_example_035 where
+
+import ForSyDe.Shallow
+
+-- Netlist
+system s_in_x s_in_y = (s_out_x, s_out_y)
+  where
+    (s_out_x, s_out_y) = a_a s_in_x s_in_y
+
+-- Process Constructors
+-- a_a :: Num a => Signal a -> Signal a -> (Signal a, Signal a)
+a_a = actor22SDF (1, 1) (1, 1) undefined

--- a/forsyde-devtools.cabal
+++ b/forsyde-devtools.cabal
@@ -92,9 +92,7 @@ executable forsyde-lsp-exe
     CoreIR
     CoreIRToForSyDeIR
     ForSyDeIR
-    ForSyDeIRToProceduralIR
     ProceduralIR
-    ProceduralIRToC
     SDFSchedule
     SKGraphSchema
     Utilities

--- a/src/CoreIRToForSyDeIR.hs
+++ b/src/CoreIRToForSyDeIR.hs
@@ -93,16 +93,21 @@ translateSystem initialContext expr = case expr of
     let context1 = translateSystemBinds initialContext [(b, e)]
         context2 = translateSystem context1 out
      in context2
-  _ ->
-    let outputs = translateOutputs initialContext expr
-        context1 = foldl updateSystemOutput initialContext outputs
-        context2 =
-          context1
-            { systemInputs = reverse (systemInputs context1),
-              systemOutputs = reverse (systemOutputs context1)
-            }
-        context3 = updateConstructorsAndSignals context2
-     in context3
+  Case (Let (Rec binds) out) _ _ _alts ->
+    let context1 = translateSystemBinds initialContext binds
+        context2 = translateSystem context1 out
+     in context2
+  _ -> case translateOutputs initialContext expr of
+    [] -> initialContext
+    outputs ->
+      let context1 = foldl updateSystemOutput initialContext outputs
+          context2 =
+            context1
+              { systemInputs = reverse (systemInputs context1),
+                systemOutputs = reverse (systemOutputs context1)
+              }
+          context3 = updateConstructorsAndSignals context2
+       in context3
 
 -- | Helper function which identifies the outputs of a system `CoreExpr`.
 translateOutputs :: TranslationContext -> CoreExpr -> [IRId]
@@ -114,18 +119,25 @@ translateOutputs context expr = aux expr []
       App _ (Type _) -> outputs
       App e (Var out) -> aux e ((IRVar out) : outputs)
       Lam _ e -> aux e outputs
+      App e1 e2 -> aux e2 (aux e1 outputs)
+      -- `Case` can be ignored, as the outputs defined within were translated
+      -- when the binder was defined
+      Case _ _ _ _alts -> outputs
       e -> error ("translateOutputs - Unsupported expression\n" ++ prettyCoreExpr (flags context) e)
 
 updateSystemOutput :: TranslationContext -> IRId -> TranslationContext
 updateSystemOutput initialContext outputId =
-  let (sourceId, sourceRate) = getSourceFromArgument initialContext outputId
-      newSignal = IRSignal outputId (sourceId, sourceRate) (outputId, 1)
-      context1 =
-        initialContext
-          { systemOutputs = outputId : (systemOutputs initialContext),
-            signals = (outputId, newSignal) : (signals initialContext)
-          }
-   in context1
+  if not (outputId `elem` (map fst (signals initialContext)))
+    then
+      let (sourceId, sourceRate) = getSourceFromArgument initialContext outputId
+          newSignal = IRSignal outputId (sourceId, sourceRate) (outputId, 1)
+          context1 =
+            initialContext
+              { systemOutputs = outputId : (systemOutputs initialContext),
+                signals = (outputId, newSignal) : (signals initialContext)
+              }
+       in context1
+    else initialContext
 
 -- | Updates all the signals within `TranslationContext` which are temporarily
 -- using a binder as the signal source. Replaces them with their associated
@@ -198,6 +210,14 @@ translateSystemBinds initialcontext = foldl' translateSystemBind initialcontext
 -- potentially updated `TranslationContext`.
 translateSystemExpr :: TranslationContext -> CoreExpr -> (Binder, TranslationContext)
 translateSystemExpr initialContext expr = case expr of
+  -- Explicitly ignores lambdas refering to type-level binders
+  Lam b e | (isTyCoVar b || (isPredTy . varType) b) -> translateSystemExpr initialContext e
+  Let (NonRec b e) out ->
+    let bindingId = IRVar b
+        context1 = translateSystemBinds initialContext [(b, e)]
+        context2 = translateSystem context1 out
+        binder = PcId bindingId
+     in (binder, context2)
   Case (Var i) _ _ alts ->
     let bindingId = IRVar i
         index = getIndexFromAlts initialContext alts

--- a/src/CoreIRToForSyDeIR.hs
+++ b/src/CoreIRToForSyDeIR.hs
@@ -77,9 +77,8 @@ translateCoreBind _ (Rec _) = error "translateCoreBind - `Rec` used in top level
 -- and identifies system outputs.
 translateSystem :: TranslationContext -> CoreExpr -> TranslationContext
 translateSystem initialContext expr = case expr of
-  -- Ignores Lambdas that refer to binders which are typed, always comes in
-  -- pairs. These Lambdas are resent when no explicit type is declared.
-  Lam b (Lam _ e) | isTyVar b -> translateSystem initialContext e
+  -- Explicitly ignores lambdas refering to type-level binders
+  Lam b e | (isTyCoVar b || (isPredTy . varType) b) -> translateSystem initialContext e
   Lam b e ->
     let newInput = IRVar b
         context1 = initialContext {systemInputs = newInput : (systemInputs initialContext)}
@@ -310,7 +309,8 @@ getSourceFromArgument context argument =
 -- level definition.
 stripLams :: Integer -> CoreExpr -> (Integer, CoreExpr)
 stripLams n expr = case expr of
-  Lam b (Lam _ e) | isTyVar b -> stripLams n e
+  -- Explicitly strips lambdas refering to type-level binders
+  Lam b e | (isTyCoVar b || (isPredTy . varType) b) -> stripLams n e
   Lam _ e | otherwise -> stripLams (n + 1) e
   _ -> (n, expr)
 

--- a/src/CoreIRToForSyDeIR.hs
+++ b/src/CoreIRToForSyDeIR.hs
@@ -5,10 +5,7 @@ import Data.List (elemIndex)
 import ForSyDeIR
 import GHC hiding (targetId)
 import GHC.Core
-import GHC.Driver.Ppr (showPprUnsafe)
 import GHC.Plugins
-import GHC.Plugins (IdDetails (CoVarId))
-import GHC.Types.Var (isTyVar)
 
 -- | The `TranslationContext` is a data type which is used to pass around
 -- context required to complete the translation of Core IR to ForSyDe IR.
@@ -97,57 +94,32 @@ translateSystem initialContext expr = case expr of
     let context1 = translateSystemBinds initialContext [(b, e)]
         context2 = translateSystem context1 out
      in context2
-  _ -> translateSystemOutputs initialContext expr
+  _ ->
+    let outputs = translateOutputs initialContext expr
+        context1 = foldl updateSystemOutput initialContext outputs
+        context2 =
+          context1
+            { systemInputs = reverse (systemInputs context1),
+              systemOutputs = reverse (systemOutputs context1)
+            }
+        context3 = updateConstructorsAndSignals context2
+     in context3
 
--- | Identifies the system outputs of the netlist and does the final clean-up
--- of the `TranslationContext` by updating constructors and signals.
---
--- NOTE: This function needs to be updated with new pattern matches for
--- translation to support netlists with additional system ouputs.
-translateSystemOutputs :: TranslationContext -> CoreExpr -> TranslationContext
-translateSystemOutputs initialContext expr = case expr of
-  -- System has 1 output
-  Var out ->
-    let context1 = updateSystemOutput initialContext out
-        context2 = context1 {systemInputs = reverse (systemInputs context1)}
-        context3 = updateConstructorsAndSignals context2
-     in context3
-  -- System has 2 outputs
-  App (App (App (App (Var _) (Type _)) (Type _)) (Var out1)) (Var out2) ->
-    let context1 = foldl updateSystemOutput initialContext [out1, out2]
-        context2 =
-          context1
-            { systemInputs = reverse (systemInputs context1),
-              systemOutputs = reverse (systemOutputs context1)
-            }
-        context3 = updateConstructorsAndSignals context2
-     in context3
-  -- System has 3 outputs
-  App (App (App (App (App (App (Var _) (Type _)) (Type _)) (Type _)) (Var out1)) (Var out2)) (Var out3) ->
-    let context1 = foldl updateSystemOutput initialContext [out1, out2, out3]
-        context2 =
-          context1
-            { systemInputs = reverse (systemInputs context1),
-              systemOutputs = reverse (systemOutputs context1)
-            }
-        context3 = updateConstructorsAndSignals context2
-     in context3
-  -- System has 4 outputs
-  App (App (App (App (App (App (App (App (Var _) (Type _)) (Type _)) (Type _)) (Type _)) (Var out1)) (Var out2)) (Var out3)) (Var out4) ->
-    let context1 = foldl updateSystemOutput initialContext [out1, out2, out3, out4]
-        context2 =
-          context1
-            { systemInputs = reverse (systemInputs context1),
-              systemOutputs = reverse (systemOutputs context1)
-            }
-        context3 = updateConstructorsAndSignals context2
-     in context3
-  _ -> error ("translateSystemOutputs - Unsupported expression\n" ++ prettyCoreExpr (flags initialContext) expr)
+-- | Helper function which identifies the outputs of a system `CoreExpr`.
+translateOutputs :: TranslationContext -> CoreExpr -> [IRId]
+translateOutputs context expr = aux expr []
+  where
+    aux currentExpr outputs = case currentExpr of
+      Var out -> (IRVar out) : outputs
+      App (Var out) (Type _) -> (IRVar out) : outputs
+      App _ (Type _) -> outputs
+      App e (Var out) -> aux e ((IRVar out) : outputs)
+      Lam _ e -> aux e outputs
+      e -> error ("translateOutputs - Unsupported expression\n" ++ prettyCoreExpr (flags context) e)
 
-updateSystemOutput :: TranslationContext -> Id -> TranslationContext
-updateSystemOutput initialContext output =
-  let outputId = IRVar output
-      (sourceId, sourceRate) = getSourceFromArgument initialContext outputId
+updateSystemOutput :: TranslationContext -> IRId -> TranslationContext
+updateSystemOutput initialContext outputId =
+  let (sourceId, sourceRate) = getSourceFromArgument initialContext outputId
       newSignal = IRSignal outputId (sourceId, sourceRate) (outputId, 1)
       context1 =
         initialContext
@@ -225,89 +197,31 @@ translateSystemBinds initialcontext = foldl' translateSystemBind initialcontext
 -- application of a process constructor or connection to a specific output of a
 -- process constructor. In either case returns a `Binder` along side a
 -- potentially updated `TranslationContext`.
---
--- NOTE: This function needs to be updated with new pattern matches for
--- translation to support process constructors with more inputs.
 translateSystemExpr :: TranslationContext -> CoreExpr -> (Binder, TranslationContext)
 translateSystemExpr initialContext expr = case expr of
-  -- Application of process constructors with 1 input
-  App (Var i) (Var a) ->
-    let pcId = IRVar i
-        aId = IRVar a
-        arguments = [aId]
-        context1 = createSignalsFromArguments initialContext pcId arguments
-        binder = PcId pcId
-     in (binder, context1)
-  App (App (App (Var i) (Type _)) (Var _)) (Var a) ->
-    let pcId = IRVar i
-        aId = IRVar a
-        arguments = [aId]
-        context1 = createSignalsFromArguments initialContext pcId arguments
-        binder = PcId pcId
-     in (binder, context1)
-  -- Application of process constructors with 2 input
-  App (App (Var i) (Var a1)) (Var a2) ->
-    let pcId = IRVar i
-        a1Id = IRVar a1
-        a2Id = IRVar a2
-        arguments = [a1Id, a2Id]
-        context1 = createSignalsFromArguments initialContext pcId arguments
-        binder = PcId pcId
-     in (binder, context1)
-  App (App (App (App (Var i) (Type _)) (Var _)) (Var a1)) (Var a2) ->
-    let pcId = IRVar i
-        a1Id = IRVar a1
-        a2Id = IRVar a2
-        arguments = [a1Id, a2Id]
-        context1 = createSignalsFromArguments initialContext pcId arguments
-        binder = PcId pcId
-     in (binder, context1)
-  -- Application of process constructors with 3 input
-  App (App (App (Var i) (Var a1)) (Var a2)) (Var a3) ->
-    let pcId = IRVar i
-        a1Id = IRVar a1
-        a2Id = IRVar a2
-        a3Id = IRVar a3
-        arguments = [a1Id, a2Id, a3Id]
-        context1 = createSignalsFromArguments initialContext pcId arguments
-        binder = PcId pcId
-     in (binder, context1)
-  App (App (App (App (App (Var i) (Type _)) (Var _)) (Var a1)) (Var a2)) (Var a3) ->
-    let pcId = IRVar i
-        a1Id = IRVar a1
-        a2Id = IRVar a2
-        a3Id = IRVar a3
-        arguments = [a1Id, a2Id, a3Id]
-        context1 = createSignalsFromArguments initialContext pcId arguments
-        binder = PcId pcId
-     in (binder, context1)
-  -- Application of process constructors with 4 input
-  App (App (App (App (Var i) (Var a1)) (Var a2)) (Var a3)) (Var a4) ->
-    let pcId = IRVar i
-        a1Id = IRVar a1
-        a2Id = IRVar a2
-        a3Id = IRVar a3
-        a4Id = IRVar a4
-        arguments = [a1Id, a2Id, a3Id, a4Id]
-        context1 = createSignalsFromArguments initialContext pcId arguments
-        binder = PcId pcId
-     in (binder, context1)
-  App (App (App (App (App (App (Var i) (Type _)) (Var _)) (Var a1)) (Var a2)) (Var a3)) (Var a4) ->
-    let pcId = IRVar i
-        a1Id = IRVar a1
-        a2Id = IRVar a2
-        a3Id = IRVar a3
-        a4Id = IRVar a4
-        arguments = [a1Id, a2Id, a3Id, a4Id]
-        context1 = createSignalsFromArguments initialContext pcId arguments
-        binder = PcId pcId
-     in (binder, context1)
   Case (Var i) _ _ alts ->
     let bindingId = IRVar i
         index = getIndexFromAlts initialContext alts
         binder = Binding bindingId index
      in (binder, initialContext)
-  _ -> error ("translateSystemExpr - Unsupported CoreExpr:\n" ++ prettyCoreExpr (flags initialContext) expr)
+  _ ->
+    let (pcId, argumentIds) = translateProcessApplication initialContext expr
+        context1 = createSignalsFromArguments initialContext pcId argumentIds
+        binder = PcId pcId
+     in (binder, context1)
+
+-- | Helper function which identifies the process being applied and its arguments, within a system `CoreExpr`.
+translateProcessApplication :: TranslationContext -> CoreExpr -> (IRId, [IRId])
+translateProcessApplication context expr = aux expr []
+  where
+    aux currentExpr arguments = case currentExpr of
+      Var i -> (IRVar i, arguments)
+      (App (App (Var i) (Type _)) (Var _)) -> (IRVar i, arguments)
+      App e (Var a) | isId a -> aux e ((IRVar a) : arguments)
+      App e (App (Var a) (Type _)) -> aux e ((IRVar a) : arguments)
+      App e (Type _) -> aux e arguments
+      Lam _ e -> aux e arguments
+      e -> error ("translateProcessApplication - Unsupported CoreExpr:\n" ++ prettyCoreExpr (flags context) e)
 
 -- | Helper function which identifies the id chosen by an `AltCon` for a `Case`.
 -- Returns the index of the identified id from a list of ids. These ids

--- a/src/CoreIRToProceduralIR.hs
+++ b/src/CoreIRToProceduralIR.hs
@@ -116,9 +116,8 @@ getFunctionDefinition context parametersList functionId =
 -- matched binder represents.
 translateFunctionExpr :: TranslationContext -> Int -> Int -> CoreExpr -> TranslationContext
 translateFunctionExpr context inputId inputIndex expr = case expr of
-  -- Ignores Lambdas that refer to binders which are typed, always comes in
-  -- pairs. These Lambdas are resent when no explicit type is declared.
-  Lam b (Lam _ e) | isTyVar b -> translateFunctionExpr context inputId inputIndex e
+  -- Explicitly ignore lambdas refering to type-level binders
+  Lam b e | (isTyCoVar b || (isPredTy . varType) b) -> translateFunctionExpr context inputId inputIndex e
   -- Function with 4 inputs
   Lam b1 (Lam b2 (Lam b3 (Lam b4 e))) ->
     let context1 = context {functionInputs = [(IRVar b1), (IRVar b2), (IRVar b3), (IRVar b4)]}

--- a/src/Utilities.hs
+++ b/src/Utilities.hs
@@ -94,41 +94,57 @@ compileToCoreWithForSyDePath forSyDePath filePath = runGhc (Just libdir) $ do
 -- Solution is inspired by discussions from the GHC API issue:
 -- https://gitlab.haskell.org/ghc/ghc/-/issues/24386
 noInlineTypecheck :: TcGblEnv -> TcGblEnv
-noInlineTypecheck tcg = tcg {tcg_binds = applySystemBinds (tcg_binds tcg)}
+noInlineTypecheck tcg = tcg {tcg_binds = noInline (tcg_binds tcg)}
   where
-    applySystemBinds :: (Data a) => a -> a
-    applySystemBinds = gmapT (applySystemBinds `extT` checkFunBind)
-
-    checkFunBind :: HsBind GhcTc -> HsBind GhcTc
-    checkFunBind bind =
-      case bind of
-        FunBind {fun_id = var, fun_matches = matches} ->
-          bind {fun_id = var, fun_matches = applyLocalBinds matches}
-        _ -> applySystemBinds bind
-
-    applyLocalBinds :: (Data a) => a -> a
-    applyLocalBinds = gmapT (applyLocalBinds `extT` noInlineBinds)
+    noInline :: (Data a) => a -> a
+    noInline =
+      gmapT
+        ( noInline
+            `extT` noInlineBinds
+            `extT` noInlinePat
+            `extT` noInlineExpr
+        )
 
     noInlineId :: Id -> Id
     noInlineId var = var `setInlinePragma` neverInlinePragma
 
     noInlineBinds :: HsBind GhcTc -> HsBind GhcTc
     noInlineBinds bind = case bind of
-      VarBind {var_id = var, var_rhs = rhs} -> bind {var_id = noInlineId var, var_rhs = applyLocalBinds rhs}
-      FunBind {fun_id = var, fun_matches = matches} -> bind {fun_id = noInlineId <$> var, fun_matches = applyLocalBinds matches}
-      PatBind {pat_lhs = lhs, pat_rhs = rhs} -> bind {pat_lhs = noInlinePat <$> lhs, pat_rhs = applyLocalBinds rhs}
-      XHsBindsLR absBinds -> XHsBindsLR (noInlineAbsBinds absBinds)
+      VarBind {var_id = var, var_rhs = rhs} ->
+        bind {var_id = noInlineId var, var_rhs = noInline rhs}
+      FunBind {fun_id = var, fun_matches = matches} ->
+        bind {fun_id = noInlineId <$> var, fun_matches = noInline matches}
+      PatBind {pat_lhs = lhs, pat_rhs = rhs} ->
+        bind {pat_lhs = noInline lhs, pat_rhs = noInline rhs}
+      XHsBindsLR absBinds ->
+        XHsBindsLR (noInlineAbsBinds absBinds)
       _ -> bind
 
     noInlinePat :: Pat GhcTc -> Pat GhcTc
     noInlinePat pattern = case pattern of
       VarPat ext var -> VarPat ext (noInlineId <$> var)
-      _ -> gmapT (id `extT` noInlinePat) pattern
+      _ -> gmapT noInline pattern
+
+    noInlineExpr :: HsExpr GhcTc -> HsExpr GhcTc
+    noInlineExpr expr = case expr of
+      HsCase x scrutiny matches ->
+        HsCase x (noInline scrutiny) (noInline matches)
+      HsLet x binds inner ->
+        HsLet x (noInline binds) (noInline inner)
+      _ -> gmapT noInline expr
 
     noInlineAbsBinds :: AbsBinds -> AbsBinds
     noInlineAbsBinds absBinds@AbsBinds {abs_binds = binds, abs_exports = exports} =
-      absBinds {abs_binds = binds, abs_exports = map noInlineABE exports}
+      absBinds
+        { abs_binds = fmap skipFirstHsBind <$> binds,
+          abs_exports = map noInlineABE exports
+        }
       where
+        skipFirstHsBind :: HsBind GhcTc -> HsBind GhcTc
+        skipFirstHsBind bind = case bind of
+          XHsBindsLR b -> XHsBindsLR (noInlineAbsBinds b)
+          _ -> gmapT noInline bind
+
         noInlineABE :: ABExport -> ABExport
         noInlineABE abe@ABE {abe_poly = poly, abe_mono = mono} =
           abe {abe_poly = noInlineId poly, abe_mono = noInlineId mono}


### PR DESCRIPTION
Fixes various edge cases relating to undefined functions for processes that do not use type declarations. The pr also makes various simplifications and improvements to the compiler.

- Simplifies process application and system output pattern matching.
- Refactors how type-level lambdas are ignored based on work done by @klarasm.
- Adds pattern matching to support systems that use undefined functions with no type declarations.
- Adds SDF examples to test changes.
- Removes unnecessary modules from LSP executable in cabal file.

Note that there might be additional edge cases relating to undefined functions without type declarations. Nevertheless the changes from this pr works for all current SDF examples and the newly added ones.