### PR TITLE
LSP: add schedulability and buffer sizes

### DIFF
--- a/src/LSP.hs
+++ b/src/LSP.hs
@@ -51,8 +51,8 @@ setPreferencesMethod :: LSP.SMethod (LSP.Method_CustomMethod "keith/preferences/
 setPreferencesMethod = (LSP.SMethod_CustomMethod (Proxy @"keith/preferences/setPreferences"))
 
 -- | Convert ForSyDe IR into the graph representation understood by KLighD
-forSyDeIRToGraph :: FilePath -> IRSystem -> GraphElement
-forSyDeIRToGraph filename (IRSystem (inputs, outputs) actors signals _) = graph
+forSyDeIRToGraph :: FilePath -> IRSystem -> Maybe Schedule -> GraphElement
+forSyDeIRToGraph filename (IRSystem (inputs, outputs) actors signals _) sched = graph
   where
     -- \| Create a port with a label for signal rate
     createPort parent rends props (n, _) =
@@ -134,8 +134,16 @@ forSyDeIRToGraph filename (IRSystem (inputs, outputs) actors signals _) = graph
         tn = "$root$N$" <> T.show tname <> "$P$" <> T.show n
         name = sn <> "$E$" <> T.show n
         sigid = name <> "$L$" <> T.show n
-        srclabel = if delayId sname actors then [] else [KLabel {gid = sigid <> T.show sname, label = T.show srate, properties = [EdgeLabelsPlacement 2]}]
-        tgtlabel = if delayId tname actors then [] else [KLabel {gid = sigid <> T.show tname, label = T.show trate, properties = [EdgeLabelsPlacement 1]}]
+        srclabel = if delayId sname actors then [] else [KLabel {gid = sigid <> "$" <> T.show sname, label = T.show srate, properties = [EdgeLabelsPlacement 2]}]
+        tgtlabel = if delayId tname actors then [] else [KLabel {gid = sigid <> "$" <> T.show tname, label = T.show trate, properties = [EdgeLabelsPlacement 1]}]
+        siglabel = [KLabel {gid = sigid, label = T.show n, properties = []}]
+        -- Only show the buffer size if this is the non-delayed signal
+        buflabel = case sched of
+          Just (Schedule (_, buffers, _)) ->
+            case lookup n buffers of
+              Just size -> [KLabel {gid = sigid, label = "|" <> T.show n <> "| = " <> T.show size, properties = []}]
+              Nothing -> siglabel
+          Nothing -> siglabel
         c =
           if n == sname
             then tgtlabel
@@ -143,7 +151,7 @@ forSyDeIRToGraph filename (IRSystem (inputs, outputs) actors signals _) = graph
               if n == tname
                 then srclabel
                 else
-                  [KLabel {gid = sigid, label = T.show n, properties = []}]
+                  buflabel
                     <> srclabel
                     <> tgtlabel
         edge =
@@ -207,15 +215,15 @@ updateOptions f _clientId =
     ]
 
 -- | Send the graph for layout and display to the LSP client (KLighD-VSCode)
-requestBounds :: FilePath -> T.Text -> IRSystem -> A.Value
-requestBounds f _clientId ir =
+requestBounds :: FilePath -> T.Text -> IRSystem -> Maybe Schedule -> A.Value
+requestBounds f _clientId ir sched =
   A.object
     [ "clientId" .= _clientId,
       "action"
         .= A.object
           [ "kind" .= ("requestBounds" :: T.Text),
             "newRoot"
-              .= forSyDeIRToGraph f ir
+              .= forSyDeIRToGraph f ir sched
           ]
     ]
 
@@ -369,12 +377,12 @@ handlers =
          in s <> a
     sendModel :: LSP.LspT Config IO ()
     sendModel = do
-      config@Config {file = f, clientId = c, system = s} <- LSP.getConfig
+      config@Config {file = f, clientId = c, system = s, schedule = curSched} <- LSP.getConfig
       case (f, c, s) of
         (Just curFile, Just curId, Just curSystem) ->
           LSP.sendNotification diagramAcceptMethod (setSynthesis curId)
             >> LSP.sendNotification diagramAcceptMethod (updateOptions curFile curId)
-            >> LSP.sendNotification diagramAcceptMethod (requestBounds curFile curId curSystem)
+            >> LSP.sendNotification diagramAcceptMethod (requestBounds curFile curId curSystem curSched)
         _ -> dualLogger <& ("does not have enough information to send diagram: " <> T.show config) `L.WithSeverity` L.Error
     recomputeModel :: LSP.LspT Config IO ()
     recomputeModel = do
@@ -517,7 +525,8 @@ run (Arguments comm (Host ip) (TCP p) i_f pkgPath) =
     (InputFile f, _) -> do
       (core, dflags) <- liftIO $ compileToCoreWithForSyDePath pkgPath f
       let (forsydeIR, _lookupSignals) = translateCoreProgram dflags core
-      let graphMessage = requestBounds f "sprotty" forsydeIR
+      let sched = coerce $ computeScheduleAndBuffers forsydeIR
+      let graphMessage = requestBounds f "sprotty" forsydeIR (Just sched)
       BSL8.putStrLn $ AP.encodePretty graphMessage
   where
     serverDef =

--- a/src/LSP.hs
+++ b/src/LSP.hs
@@ -20,6 +20,7 @@ import qualified Data.Aeson as A
 import qualified Data.Aeson.Encode.Pretty as AP
 import Data.Aeson.KeyMap ((!?))
 import qualified Data.ByteString.Lazy.Char8 as BSL8
+import Data.Coerce
 import qualified Data.Foldable as F
 import Data.Function
 import qualified Data.List.NonEmpty as NE
@@ -35,6 +36,7 @@ import qualified Language.LSP.Server as LSP
 import Network.Socket
 import Options.Applicative
 import Prettyprinter
+import SDFSchedule (computeScheduleAndBuffers)
 import SKGraphSchema
 import System.IO
 import Utilities (compileToCoreWithForSyDePath)
@@ -240,10 +242,14 @@ diagramOpenInTextEditorMessage uri sline scol eline ecol =
       "forceOpen" .= False
     ]
 
+newtype Schedule = Schedule ([IRId], [(IRId, Int)], [(IRId, IRId)])
+  deriving (Show)
+
 data Config = Config
   { file :: Maybe FilePath,
     clientId :: Maybe T.Text,
     system :: Maybe IRSystem,
+    schedule :: Maybe Schedule,
     forSyDePkg :: Maybe FilePath
   }
   deriving (Show)
@@ -254,6 +260,7 @@ defaultConfig =
     { file = Nothing,
       clientId = Nothing,
       system = Nothing,
+      schedule = Nothing,
       forSyDePkg = Nothing
     }
 
@@ -378,8 +385,11 @@ handlers =
         _ -> pure Nothing
       case out of
         Nothing -> pure ()
-        Just _ ->
+        Just ir -> do
           LSP.setConfig config {system = out}
+          sched <- computeScheduleMaybe ir
+          LSP.setConfig config {system = out, schedule = coerce sched}
+          pure ()
     compileToModelMaybe f = do
       config <- LSP.getConfig
       dualLogger <& ("Compiling: " <> T.show f) `L.WithSeverity` L.Debug
@@ -395,6 +405,13 @@ handlers =
               dualLogger <& ("Failed to compile into ForSyDe IR: " <> T.show (e :: E.ErrorCall)) `L.WithSeverity` L.Error
               pure $ system config
             Right (ir, _) -> pure $ Just ir
+    computeScheduleMaybe ir = do
+      result <- liftIO $ E.try $ E.evaluate $ computeScheduleAndBuffers ir
+      case result of
+        Left e -> do
+          dualLogger <& ("Failed to compute schedule: " <> T.show (e :: E.ErrorCall)) `L.WithSeverity` L.Error
+          pure Nothing
+        Right sched -> pure . Just $ sched
     findSignalSpan :: IRId -> [IRSignal] -> [IRSpan]
     findSignalSpan sig l = mapMaybe match l
       where


### PR DESCRIPTION
As a first step, compute the schedule in the LSP. This time the exception handling actually seems to work, and we get an error in VSCode when it is not schedulable.