### PR TITLE
Add CI Workflow for Github Release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,15 +25,32 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v5
-      - uses: cachix/install-nix-action@v31
-        with:
-          nix_path: nixpkgs=channel:25.05
 
-        # Runs a set of commands using the runners shell
-      - name: Build and test the compiler
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libblas-dev liblapack-dev
+
+      - name: Setup Haskell (Stack)
+        uses: haskell-actions/setup@v2
+        with:
+          enable-stack: true
+          stack-version: 'latest'
+          stack-no-global: true
+
+      - name: Cache Stack dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.stack
+          key: stack-${{ runner.os }}-${{ hashFiles('stack.yaml', 'stack.yaml.lock', 'forsyde-devtools.cabal') }}
+          restore-keys: |
+            stack-${{ runner.os }}-
+
+      - name: Build the compiler
         run: |
           git fetch origin dev
-          if git diff --stat origin/dev -- | grep '\(^ src\|^ test\|^ flake.nix\|^ flake.lock\|^ forsyde-devtools.cabal\|^ cabal.project\)'; then
-            nix develop --command bash -c "cabal build"
-            nix develop --command bash -c "cabal test"
+          if git diff --stat origin/dev -- | grep '\(^ src\|^ test\|^ flake.nix\|^ flake.lock\|^ forsyde-devtools.cabal\|^ cabal.project\|^ stack.yaml\)'; then
+            stack build
+            # TODO: re-enable tests once test suite is ready
+            # stack test
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,101 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-haskell:
+    name: Build Haskell Binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:25.05
+
+      - name: Build binaries
+        run: |
+          nix develop --command bash -c "cabal update && cabal build all"
+
+      - name: Package binaries
+        run: |
+          mkdir -p dist/bin
+          # Find and copy the executables produced by cabal
+          # They are usually deeply nested in dist-newstyle, so we use find
+          find dist-newstyle -type f -executable -name "forsyde-compiler-exe" -exec cp {} dist/bin/ \;
+          find dist-newstyle -type f -executable -name "forsyde-lsp-exe" -exec cp {} dist/bin/ \;
+          
+          # Create an archive
+          cd dist
+          tar -czvf forsyde-devtools-linux-x86_64.tar.gz bin/
+
+      - name: Upload Haskell artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: haskell-binaries
+          path: dist/forsyde-devtools-linux-x86_64.tar.gz
+          retention-days: 1
+
+  build-vscode-ext:
+    name: Build VS Code Extension
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: vscode-ext/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          cd vscode-ext
+          npm install
+
+      - name: Build and Package VSIX
+        run: |
+          cd vscode-ext
+          npm run compile
+          npx vsce package --out forsyde-vscode-extension.vsix
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vscode-extension
+          path: vscode-ext/forsyde-vscode-extension.vsix
+          retention-days: 1
+
+  release:
+    name: Create GitHub Release
+    needs: [build-haskell, build-vscode-ext]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to create releases
+    steps:
+      - name: Download Haskell artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: haskell-binaries
+
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: vscode-extension
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            forsyde-devtools-linux-x86_64.tar.gz
+            forsyde-vscode-extension.vsix
+          generate_release_notes: true
+          draft: false
+          prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,23 +13,35 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libblas-dev liblapack-dev
+
+      - name: Setup Haskell (Stack)
+        uses: haskell-actions/setup@v2
         with:
-          nix_path: nixpkgs=channel:25.05
+          enable-stack: true
+          stack-version: 'latest'
+          stack-no-global: true
+
+      - name: Cache Stack dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.stack
+          key: stack-${{ runner.os }}-${{ hashFiles('stack.yaml', 'stack.yaml.lock', 'forsyde-devtools.cabal') }}
+          restore-keys: |
+            stack-${{ runner.os }}-
 
       - name: Build binaries
         run: |
-          nix develop --command bash -c "cabal update && cabal build all"
+          stack build
 
       - name: Package binaries
         run: |
           mkdir -p dist/bin
-          # Find and copy the executables produced by cabal
-          # They are usually deeply nested in dist-newstyle, so we use find
-          find dist-newstyle -type f -executable -name "forsyde-compiler-exe" -exec cp {} dist/bin/ \;
-          find dist-newstyle -type f -executable -name "forsyde-lsp-exe" -exec cp {} dist/bin/ \;
-          
+          stack install --local-bin-path dist/bin
+
           # Create an archive
           cd dist
           tar -czvf forsyde-devtools-linux-x86_64.tar.gz bin/


### PR DESCRIPTION
Add CI Workflow that create github release when we push a tag that starts with v, such as v123456, or v1.2.3.4 or even tag named "vaxholm". See image below.

The release contains two important outcomes:
1. Compressed file `something-something.tar.gz` which bundles the `forsyde-lsp-exe` and `forsyde-compiler-exe` for Linux. (windows and mac later)
2. VS Code extension in `.vsix` format 

<img width="1236" height="563" alt="image" src="https://github.com/user-attachments/assets/eb6ce7f7-736e-424a-bc9e-334f2764c4be" />

Note: I accidentally rebased on a unmerged PR, so do not merge before PR #341 is merged. 