### PR TITLE
Add support for ForSyDe-Atom SDF

### DIFF
--- a/examples/atom/SDF_example_001.hs
+++ b/examples/atom/SDF_example_001.hs
@@ -1,0 +1,27 @@
+module SDF_example_001 where
+
+import qualified ForSyDe.Atom.MoC.SDF as SDF
+
+system :: SDF.Signal Int -> SDF.Signal Int -> SDF.Signal Int
+system s_in_x s_in_y = s_out
+  where
+    s_1 = a_a s_in_x s_in_y
+    (s_out, s_2) = a_b s_1 s_2_delayed
+    s_2_delayed = d_1 s_2
+
+-- Process specifications
+a_a :: SDF.Signal Int -> SDF.Signal Int -> SDF.Signal Int
+a_a s_1 s_2 = SDF.actor21 ((1, 1), 1, add) s_1 s_2
+
+a_b :: SDF.Signal Int -> SDF.Signal Int -> (SDF.Signal Int, SDF.Signal Int)
+a_b s_1 s_2 = SDF.actor22 ((1, 1), (1, 1), accumulate) s_1 s_2
+
+d_1 :: SDF.Signal Int -> SDF.Signal Int
+d_1 s = SDF.delay [0] s
+
+-- Function definitions
+add :: [Int] -> [Int] -> [Int]
+add [x] [y] = [x + y]
+
+accumulate :: [Int] -> [Int] -> ([Int], [Int])
+accumulate [x] [y] = ([x + y], [x + y])

--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,23 @@
         "type": "github"
       }
     },
+    "forsyde-atom": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1762522343,
+        "narHash": "sha256-+/7u9DMy5BrNE7ryf6Ncy9L5Q4mKjrFyD3jYxFQvir0=",
+        "owner": "forsyde",
+        "repo": "forsyde-atom",
+        "rev": "a24e65741832fe807cd530e160934d5156c76460",
+        "type": "github"
+      },
+      "original": {
+        "owner": "forsyde",
+        "repo": "forsyde-atom",
+        "rev": "a24e65741832fe807cd530e160934d5156c76460",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1759632233,
@@ -37,6 +54,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "forsyde-atom": "forsyde-atom",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,23 @@
 {
   description = "ForSyDe Development Flake";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    forsyde-atom = {
+      url = "github:forsyde/forsyde-atom/a24e65741832fe807cd530e160934d5156c76460";
+      flake = false;
+    };
+  };
 
   outputs =
-    { self, flake-utils, ... }@inputs:
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      forsyde-atom,
+      ...
+    }@inputs:
     let
       ghcVersion = "ghc9102";
       overlay = final: prev: {
@@ -13,6 +25,18 @@
           packages = prev.haskell.packages // {
             "${ghcVersion}" = prev.haskell.packages.${ghcVersion}.extend (
               hfinal: hprev: {
+                forsyde-atom =
+                  let
+                    pkg = hfinal.callCabal2nix "forsyde-atom" forsyde-atom { };
+                  in
+                  final.haskell.lib.compose.overrideCabal (old: {
+                    # cabal fails due to haddock include wildcard fails, using a
+                    # dummy file as a workaround
+                    postPatch = ''
+                      mkdir -p fig
+                      touch fig/dummy.png
+                    '';
+                  }) pkg;
                 forsyde-devtools =
                   let
                     unmodified = hprev.callCabal2nix "forsyde-devtools" ./. { };

--- a/forsyde-devtools.cabal
+++ b/forsyde-devtools.cabal
@@ -24,6 +24,7 @@ common common-options
     co-log-core ==0.3.2.5,
     containers ==0.7,
     filepath >=1 && <1.6,
+    forsyde-atom >=0.3.2 && <=0.3.3,
     forsyde-shallow ==3.5.0.0,
     ghc ==9.10.2,
     ghc-paths ==0.1.0.12,

--- a/src/CoreIRToForSyDeIR.hs
+++ b/src/CoreIRToForSyDeIR.hs
@@ -423,6 +423,7 @@ translateCoreExpr context' binder expr' =
         _ -> (context', expr1)
       expr = maybe expr' id (stripApps n expr2)
    in case expr of
+        -- ForSyDe-Shallow SDF
         App (App (Var i) _) _
           | IRVar i == IRString "delaySDF" -> createDelaySDF context binder expr
         App (App (App (App (App (Var i) _) _) _) _) _
@@ -448,6 +449,32 @@ translateCoreExpr context' binder expr' =
           | IRVar i == IRString "actor43SDF" -> createActorSDF context Actor43 binder expr
         App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _
           | IRVar i == IRString "actor44SDF" -> createActorSDF context Actor44 binder expr
+        -- ForSyDe-Atom SDF
+        App (App (Var i) _) _
+          | IRVar i == IRString "delay" -> createDelaySDF context binder expr
+        App (App (App (Var i) _) _) _
+          | IRVar i == IRString "actor11" -> createActorSDF context Actor11 binder expr
+        App (App (App (App (Var i) _) _) _) _
+          | IRVar i == IRString "actor12" -> createActorSDF context Actor12 binder expr
+          | IRVar i == IRString "actor21" -> createActorSDF context Actor21 binder expr
+        App (App (App (App (App (Var i) _) _) _) _) _
+          | IRVar i == IRString "actor13" -> createActorSDF context Actor13 binder expr
+          | IRVar i == IRString "actor22" -> createActorSDF context Actor22 binder expr
+          | IRVar i == IRString "actor31" -> createActorSDF context Actor31 binder expr
+        App (App (App (App (App (App (Var i) _) _) _) _) _) _
+          | IRVar i == IRString "actor14" -> createActorSDF context Actor14 binder expr
+          | IRVar i == IRString "actor23" -> createActorSDF context Actor23 binder expr
+          | IRVar i == IRString "actor32" -> createActorSDF context Actor32 binder expr
+          | IRVar i == IRString "actor41" -> createActorSDF context Actor41 binder expr
+        App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _
+          | IRVar i == IRString "actor24" -> createActorSDF context Actor24 binder expr
+          | IRVar i == IRString "actor33" -> createActorSDF context Actor33 binder expr
+          | IRVar i == IRString "actor43" -> createActorSDF context Actor42 binder expr
+        App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _
+          | IRVar i == IRString "actor34" -> createActorSDF context Actor34 binder expr
+          | IRVar i == IRString "actor43" -> createActorSDF context Actor43 binder expr
+        App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _
+          | IRVar i == IRString "actor44" -> createActorSDF context Actor44 binder expr
         _ -> createFunction context binder expr
 
 createDelaySDF :: TranslationContext -> CoreBndr -> CoreExpr -> TranslationContext

--- a/src/CoreIRToForSyDeIR.hs
+++ b/src/CoreIRToForSyDeIR.hs
@@ -429,31 +429,22 @@ translateCoreExpr context' binder expr' =
           | IRVar i == IRString "actor11SDF" -> createActorSDF context Actor11 binder expr
         App (App (App (App (App (App (Var i) _) _) _) _) _) _
           | IRVar i == IRString "actor12SDF" -> createActorSDF context Actor12 binder expr
-        App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _
-          | IRVar i == IRString "actor13SDF" -> createActorSDF context Actor13 binder expr
-        App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _
-          | IRVar i == IRString "actor14SDF" -> createActorSDF context Actor14 binder expr
-        App (App (App (App (App (App (Var i) _) _) _) _) _) _
           | IRVar i == IRString "actor21SDF" -> createActorSDF context Actor21 binder expr
         App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _
+          | IRVar i == IRString "actor13SDF" -> createActorSDF context Actor13 binder expr
           | IRVar i == IRString "actor22SDF" -> createActorSDF context Actor22 binder expr
-        App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _
-          | IRVar i == IRString "actor23SDF" -> createActorSDF context Actor23 binder expr
-        App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _
-          | IRVar i == IRString "actor24SDF" -> createActorSDF context Actor24 binder expr
-        App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _
           | IRVar i == IRString "actor31SDF" -> createActorSDF context Actor31 binder expr
         App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _
+          | IRVar i == IRString "actor14SDF" -> createActorSDF context Actor14 binder expr
+          | IRVar i == IRString "actor23SDF" -> createActorSDF context Actor23 binder expr
           | IRVar i == IRString "actor32SDF" -> createActorSDF context Actor32 binder expr
-        App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _
-          | IRVar i == IRString "actor33SDF" -> createActorSDF context Actor33 binder expr
-        App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _
-          | IRVar i == IRString "actor34SDF" -> createActorSDF context Actor34 binder expr
-        App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _
           | IRVar i == IRString "actor41SDF" -> createActorSDF context Actor41 binder expr
         App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _
+          | IRVar i == IRString "actor24SDF" -> createActorSDF context Actor24 binder expr
+          | IRVar i == IRString "actor33SDF" -> createActorSDF context Actor33 binder expr
           | IRVar i == IRString "actor42SDF" -> createActorSDF context Actor42 binder expr
         App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _
+          | IRVar i == IRString "actor34SDF" -> createActorSDF context Actor34 binder expr
           | IRVar i == IRString "actor43SDF" -> createActorSDF context Actor43 binder expr
         App (App (App (App (App (App (App (App (App (App (App (Var i) _) _) _) _) _) _) _) _) _) _) _
           | IRVar i == IRString "actor44SDF" -> createActorSDF context Actor44 binder expr

--- a/stack.yaml
+++ b/stack.yaml
@@ -47,6 +47,8 @@ packages:
 #
 extra-deps:
   - forsyde-shallow-3.5.0.0@sha256:6746d7f6173c8c7b212d7ef0ecb0a4efad8ef9399073707701973c1e5c118f9c,4377
+  - git: https://github.com/forsyde/forsyde-atom.git
+    commit: a24e65741832fe807cd530e160934d5156c76460
 
 # Override default flag values for project packages and extra-deps
 # flags: {}


### PR DESCRIPTION
The only thing needed was to add new patterns for `translateCoreExpr` in `CoreIRToForSyDeIR.hs` and adding the dependencies.

Note: I don't know how to add ForSyDe-Atom to the nix flake since it is not on hackage.