### PR TITLE
vscode-ext: invoke the lsp through stack

### DIFF
--- a/vscode-ext/client/src/extension.ts
+++ b/vscode-ext/client/src/extension.ts
@@ -94,10 +94,11 @@ function createServerOptions(context: ExtensionContext): ServerOptions {
       vscode.workspace.getConfiguration("forsydeDevtoolsLSP");
     console.log("Spawning to language server as a process.");
     const lsp_executable = context.asAbsolutePath(`server/forsyde-lsp-exe`);
+    const stack_config = context.asAbsolutePath(`client/stack.yaml`);
 
-    let args = ["--stdio"];
+    let args = ["exec", "--stack-yaml", stack_config, "--", "forsyde-lsp-exe", "--stdio"];
     if (stackPkgPath && stackPkgPath.length > 0) {
-      args = ["--forsyde-pkgpath", stackPkgPath, "--stdio"];
+      args.push("--forsyde-pkgpath", stackPkgPath);
     }
 
     if (existsSync(lsp_executable)) {
@@ -107,8 +108,8 @@ function createServerOptions(context: ExtensionContext): ServerOptions {
       };
     } else {
       return {
-        run: { command: `forsyde-lsp-exe`, args },
-        debug: { command: `forsyde-lsp-exe`, args },
+        run: { command: `stack`, args },
+        debug: { command: `stack`, args },
       };
     }
   }

--- a/vscode-ext/client/stack.yaml
+++ b/vscode-ext/client/stack.yaml
@@ -1,0 +1,7 @@
+resolver: lts-24.11
+packages: []
+
+extra-deps:
+  - forsyde-shallow-3.5.0.0@sha256:6746d7f6173c8c7b212d7ef0ecb0a4efad8ef9399073707701973c1e5c118f9c,4377
+  - git: https://github.com/forsyde/forsyde-atom.git
+    commit: a24e65741832fe807cd530e160934d5156c76460


### PR DESCRIPTION
This means that the user does not have to specify the --forsyde-pkgpath, though I'll leave it since it should not have any ill effect.

NOTE: this should probably not be merged before #344.