### PR TITLE
add release pipeline with packaged vscode extension

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # The compiler requires the OpenBLAS and LAPACK external libraries
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libblas-dev liblapack-dev
-
       - name: Set up stack
         uses: haskell-actions/setup@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+# Builds release artifacts: the VSCode extension (.vsix) with the LSP server
+# binary bundled inside, plus a tarball of the standalone binaries.
+# Runs on version tags (v*) and uploads the files as release assets.
+
+name: Release
+
+on:
+  # Triggers the workflow on version tags, e.g. v0.1.0
+  push:
+    tags: ["v*"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    # Linux x64 only for now
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # The compiler requires the OpenBLAS and LAPACK external libraries
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libblas-dev liblapack-dev
+
+      - name: Set up stack
+        uses: haskell-actions/setup@v2
+        with:
+          enable-stack: true
+          stack-version: "latest"
+
+      - name: Cache stack dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.stack
+            .stack-work
+          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml', 'stack.yaml.lock', 'forsyde-devtools.cabal') }}
+          restore-keys: |
+            ${{ runner.os }}-stack-
+
+      - name: Build the compiler and LSP
+        run: stack build
+
+      - name: Install binaries
+        run: |
+          stack path --local-install-root
+          stack install --local-bin-path "$PWD/bin"
+          ls -l bin
+
+      # The extension prefers a bundled server binary at server/forsyde-lsp-exe
+      # (relative to the extension root) over a stack-based launch
+      - name: Bundle the LSP server into the extension
+        run: |
+          mkdir -p vscode-ext/server
+          cp bin/forsyde-lsp-exe vscode-ext/server/forsyde-lsp-exe
+          chmod +x vscode-ext/server/forsyde-lsp-exe
+
+      - name: Set up node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Build and package the VSCode extension
+        working-directory: vscode-ext
+        run: |
+          npm ci
+          npm run compile
+          npm run package
+
+      - name: Package standalone binaries
+        run: tar -czf forsyde-devtools-linux-x64.tar.gz -C bin forsyde-compiler-exe forsyde-lsp-exe
+
+      - name: Upload extension artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: forsyde-vscode-extension
+          path: vscode-ext/*.vsix
+          if-no-files-found: error
+
+      - name: Upload binaries artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: forsyde-devtools-linux-x64
+          path: forsyde-devtools-linux-x64.tar.gz
+          if-no-files-found: error
+
+      - name: Attach assets to the GitHub release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            vscode-ext/*.vsix
+            forsyde-devtools-linux-x64.tar.gz

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A pre-study related to this project was conducted as part of the [II2211 Researc
 The original algorithm for generating code from SDF (Synchronous Data Flow) models written in ForSyDe can be found in this [paper](https://www.icas.org/icas_archive/ICAS2022/data/papers/ICAS2022_0604_paper.pdf).
 
 ## Installing from a release
-The easiest way to install the ForSyDe DevTools is to download a pre-built release from the [GitHub Releases](https://github.com/sthaeron/forsyde-devtools/releases) page. Each release provides the VSCode extension as a `.vsix` file, with the LSP server already bundled inside, as well as a tarball with the standalone `forsyde-compiler-exe` and `forsyde-lsp-exe` binaries. Pre-built releases are currently only available for Linux x86-64, and require the OpenBLAS and LAPACK external libraries to be installed (see the next section).
+The easiest way to install the ForSyDe DevTools is to download a pre-built release from the [GitHub Releases](https://github.com/sthaeron/forsyde-devtools/releases) page. Each release provides the VSCode extension as a `.vsix` file, with the LSP server already bundled inside, as well as a tarball with the standalone `forsyde-compiler-exe` and `forsyde-lsp-exe` binaries. Pre-built releases are currently only available for Linux x86-64.
 
 To install the extension, download the `.vsix` file from the latest release and run:
 ```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ A pre-study related to this project was conducted as part of the [II2211 Researc
 
 The original algorithm for generating code from SDF (Synchronous Data Flow) models written in ForSyDe can be found in this [paper](https://www.icas.org/icas_archive/ICAS2022/data/papers/ICAS2022_0604_paper.pdf).
 
+## Installing from a release
+The easiest way to install the ForSyDe DevTools is to download a pre-built release from the [GitHub Releases](https://github.com/sthaeron/forsyde-devtools/releases) page. Each release provides the VSCode extension as a `.vsix` file, with the LSP server already bundled inside, as well as a tarball with the standalone `forsyde-compiler-exe` and `forsyde-lsp-exe` binaries. Pre-built releases are currently only available for Linux x86-64, and require the OpenBLAS and LAPACK external libraries to be installed (see the next section).
+
+To install the extension, download the `.vsix` file from the latest release and run:
+```
+code --install-extension forsyde-vscode-extension-0.1.0.vsix
+```
+
+If you prefer to build the devtools from source instead, follow the instructions in the sections below.
+
 ## Compiler and LSP installation
 The ForSyDe DevTools compiler and LSP have been developed using a specific version of the GHC API as the frontend; the current version of GHC being used is `9.10.2`. Thus, `stack` is required to build the devtools. We suggest using [`ghcup`](https://www.haskell.org/ghcup/install/) to install it. Using your system's package manager should work too.
 

--- a/vscode-ext/client/src/extension.ts
+++ b/vscode-ext/client/src/extension.ts
@@ -96,20 +96,29 @@ function createServerOptions(context: ExtensionContext): ServerOptions {
     const lsp_executable = context.asAbsolutePath(`server/forsyde-lsp-exe`);
     const stack_config = context.asAbsolutePath(`client/stack.yaml`);
 
-    let args = ["exec", "--stack-yaml", stack_config, "--", "forsyde-lsp-exe", "--stdio"];
+    const lspArgs = ["--stdio"];
     if (stackPkgPath && stackPkgPath.length > 0) {
-      args.push("--forsyde-pkgpath", stackPkgPath);
+      lspArgs.push("--forsyde-pkgpath", stackPkgPath);
     }
+    const stackArgs = [
+      "exec",
+      "--stack-yaml",
+      stack_config,
+      "--",
+      "forsyde-lsp-exe",
+      ...lspArgs,
+    ];
 
     if (existsSync(lsp_executable)) {
+      // A bundled server binary takes the LSP arguments directly
       return {
-        run: { command: lsp_executable, args },
-        debug: { command: lsp_executable, args },
+        run: { command: lsp_executable, args: lspArgs },
+        debug: { command: lsp_executable, args: lspArgs },
       };
     } else {
       return {
-        run: { command: `stack`, args },
-        debug: { command: `stack`, args },
+        run: { command: `stack`, args: stackArgs },
+        debug: { command: `stack`, args: stackArgs },
       };
     }
   }


### PR DESCRIPTION
pushing a version tag (v0.1.0 etc) now produces a github release with an installable .vsix that has the LSP server bundled inside, plus a tarball of the standalone binaries. closes #280, progress on #133.

changes:
- new .github/workflows/release.yml, runs on v* tags and manual dispatch. stack build (cached), copies forsyde-lsp-exe into vscode-ext/server/, packages with vsce, attaches the vsix and forsyde-devtools-linux-x64.tar.gz to the release
- extension.ts: the bundled server was being launched with the stack exec args, which the binary can't parse. bundled binary now gets the lsp args directly
- README: added "installing from a release" section before the build-from-source instructions
- rebased onto dev after #348, so blas/lapack no longer needed. dropped the install step from the workflow and the blas note from the readme

linux x64 only for now, workflow can grow a matrix later. users still need stack + a compiled forsyde-shallow at runtime, the release just removes the npm/vsce/clone steps from install.

not tested end to end yet, needs a tag push or manual dispatch. maybe a v0.1.0-rc1 dispatch after merge.
